### PR TITLE
Add early return for is_covered

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -7,6 +7,9 @@ pub fn is_covered(result: &CovResult) -> bool {
         .lines
         .values()
         .any(|&execution_count| execution_count != 0);
+    if any_line_covered == false {
+        return false;
+    }
     // For JavaScript files, we can't do the same, as the top-level is always
     // executed, even if it just contains declarations. So, we need to check if
     // all its functions, except the top-level, are uncovered.

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -7,7 +7,7 @@ pub fn is_covered(result: &CovResult) -> bool {
         .lines
         .values()
         .any(|&execution_count| execution_count != 0);
-    if any_line_covered == false {
+    if !any_line_covered {
         return false;
     }
     // For JavaScript files, we can't do the same, as the top-level is always
@@ -17,7 +17,7 @@ pub fn is_covered(result: &CovResult) -> bool {
         .functions
         .iter()
         .any(|(name, ref function)| function.executed && name != "top-level");
-    any_line_covered && (result.functions.len() <= 1 || any_function_covered)
+    result.functions.len() <= 1 || any_function_covered
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #102.

Benchmarks for is_covered:

**w/o early return:**
<img width="644" alt="screen shot 2018-07-12 at 6 19 27 am" src="https://user-images.githubusercontent.com/24638220/42635739-b7066c16-859b-11e8-9ff0-4c91ffb5f65f.png">


**with early return:**
<img width="675" alt="screen shot 2018-07-12 at 6 23 56 am" src="https://user-images.githubusercontent.com/24638220/42635920-38b849f0-859c-11e8-9a77-fa62e6fd628f.png">
