### PR TITLE
Select compiler and gcov with env vars, disable GCC tests on Mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
         - GCOV=gcov-5
         - CLANG_CXX=clang++-7
         - LLVM_CONFIG=llvm-config-7
+        - DEPLOY=0
 
     - os: linux
       rust: stable
@@ -37,6 +38,7 @@ matrix:
         - GCOV=gcov-5
         - CLANG_CXX=clang++-8
         - LLVM_CONFIG=llvm-config-8
+        - DEPLOY=0
 
     - os: linux
       rust: nightly
@@ -55,6 +57,7 @@ matrix:
         - GCOV=gcov-5
         - CLANG_CXX=clang++-7
         - LLVM_CONFIG=llvm-config-7
+        - DEPLOY=0
 
     - os: linux
       rust: nightly
@@ -73,6 +76,7 @@ matrix:
         - GCOV=gcov-6
         - CLANG_CXX=clang++-7
         - LLVM_CONFIG=llvm-config-7
+        - DEPLOY=0
 
     - os: linux
       rust: nightly
@@ -91,12 +95,14 @@ matrix:
         - GCOV=gcov-7
         - CLANG_CXX=clang++-7
         - LLVM_CONFIG=llvm-config-7
+        - DEPLOY=1
 
     - os: osx
       rust: nightly
       env:
         - CLANG_CXX=clang++
         - LLVM_CONFIG=llvm-config
+        - DEPLOY=1
 install:
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sudo softwareupdate -i "Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4"; fi
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew cask uninstall --force oclint; fi
@@ -116,6 +122,6 @@ deploy:
   on:
     rust: nightly
     tags: true
-    condition: $CLANG_CXX = clang++-7 OR $CLANG_CXX = clang++
+    condition: $DEPLOY = 1
   provider: releases
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ matrix:
             - clang-7
             - g++-5
       env:
-        - GRCOV_GPP=g++-5
-        - GRCOV_CLANGPP=clang++-7
+        - GRCOV_CXX=g++-5
+        - GRCOV_CLANG_CXX=clang++-7
         - GRCOV_LLVM_CONFIG=llvm-config-7
 
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,10 @@ matrix:
             - clang-7
             - g++-5
       env:
-        - GRCOV_CXX=g++-5
-        - GRCOV_GCOV=gcov-5
-        - GRCOV_CLANG_CXX=clang++-7
-        - GRCOV_LLVM_CONFIG=llvm-config-7
+        - GCC_CXX=g++-5
+        - GCOV=gcov-5
+        - CLANG_CXX=clang++-7
+        - LLVM_CONFIG=llvm-config-7
 
     - os: linux
       rust: stable
@@ -33,10 +33,10 @@ matrix:
             - clang
             - g++-5
       env:
-        - GRCOV_CXX=g++-5
-        - GRCOV_GCOV=gcov-5
-        - GRCOV_CLANG_CXX=clang++-8
-        - GRCOV_LLVM_CONFIG=llvm-config-8
+        - GCC_CXX=g++-5
+        - GCOV=gcov-5
+        - CLANG_CXX=clang++-8
+        - LLVM_CONFIG=llvm-config-8
 
     - os: linux
       rust: nightly
@@ -51,10 +51,10 @@ matrix:
             - clang-7
             - g++-5
       env:
-        - GRCOV_CXX=g++-5
-        - GRCOV_GCOV=gcov-5
-        - GRCOV_CLANG_CXX=clang++-7
-        - GRCOV_LLVM_CONFIG=llvm-config-7
+        - GCC_CXX=g++-5
+        - GCOV=gcov-5
+        - CLANG_CXX=clang++-7
+        - LLVM_CONFIG=llvm-config-7
 
     - os: linux
       rust: nightly
@@ -69,10 +69,10 @@ matrix:
             - clang-7
             - g++-6
       env:
-        - GRCOV_CXX=g++-6
-        - GRCOV_GCOV=gcov-6
-        - GRCOV_CLANG_CXX=clang++-7
-        - GRCOV_LLVM_CONFIG=llvm-config-7
+        - GCC_CXX=g++-6
+        - GCOV=gcov-6
+        - CLANG_CXX=clang++-7
+        - LLVM_CONFIG=llvm-config-7
 
     - os: linux
       rust: nightly
@@ -87,22 +87,22 @@ matrix:
             - clang-7
             - g++-7
       env:
-        - GRCOV_CXX=g++-7
-        - GRCOV_GCOV=gcov-7
-        - GRCOV_CLANG_CXX=clang++-7
-        - GRCOV_LLVM_CONFIG=llvm-config-7
+        - GCC_CXX=g++-7
+        - GCOV=gcov-7
+        - CLANG_CXX=clang++-7
+        - LLVM_CONFIG=llvm-config-7
 
     - os: osx
       rust: nightly
       env:
-        - GRCOV_CLANG_CXX=clang++
-        - GRCOV_LLVM_CONFIG=llvm-config
+        - CLANG_CXX=clang++
+        - LLVM_CONFIG=llvm-config
 install:
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sudo softwareupdate -i "Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4"; fi
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew cask uninstall --force oclint; fi
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install llvm@7 && brew link --overwrite --force llvm@7; fi
 script:
-    - export CXX=$GRCOV_CLANG_CXX
+    - export CXX=$CLANG_CXX
     - $CXX --version
     - if [ -z "$TRAVIS_TAG" ]; then cargo build --verbose; fi
     - if [ -z "$TRAVIS_TAG" ]; then cargo test -- --nocapture; fi
@@ -116,6 +116,6 @@ deploy:
   on:
     rust: nightly
     tags: true
-    condition: $GRCOV_CLANG_CXX = clang++-7 OR $GRCOV_CLANG_CXX = clang++
+    condition: $CLANG_CXX = clang++-7 OR $CLANG_CXX = clang++
   provider: releases
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,20 +95,15 @@ matrix:
     - os: osx
       rust: nightly
       env:
-        - GRCOV_CXX=g++-7
-        - GRCOV_GCOV=gcov-7
         - GRCOV_CLANG_CXX=clang++
         - GRCOV_LLVM_CONFIG=llvm-config
 install:
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sudo softwareupdate -i "Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4"; fi
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew cask uninstall --force oclint; fi
-    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install gcc@7; fi
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install llvm@7 && brew link --overwrite --force llvm@7; fi
 script:
-    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export CXX=GRCOV_CLANG_CXX; else export CXX=GRCOV_CXX; fi
+    - export CXX=$GRCOV_CLANG_CXX
     - $CXX --version
-    - $GRCOV_GCOV --version
-    - $GRCOV_CLANG_CXX --version
     - if [ -z "$TRAVIS_TAG" ]; then cargo build --verbose; fi
     - if [ -z "$TRAVIS_TAG" ]; then cargo test -- --nocapture; fi
 before_deploy:
@@ -121,6 +116,6 @@ deploy:
   on:
     rust: nightly
     tags: true
-    condition: $GRCOV_CXX = g++-7
+    condition: $GRCOV_CLANG_CXX = clang++-7 OR $GRCOV_CLANG_CXX = clang++
   provider: releases
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,6 +106,7 @@ install:
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install llvm@7 && brew link --overwrite --force llvm@7; fi
 script:
     - export CXX=$GRCOV_CXX
+    - export CC=$GRCOV_CXX
     - $CXX --version
     - $GRCOV_GCOV --version
     - $GRCOV_CLANG_CXX --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,8 +97,8 @@ matrix:
       env:
         - GRCOV_CXX=g++-7
         - GRCOV_GCOV=gcov-7
-        - GRCOV_CLANG_CXX=clang++-7
-        - GRCOV_LLVM_CONFIG=llvm-config-7
+        - GRCOV_CLANG_CXX=clang++
+        - GRCOV_LLVM_CONFIG=llvm-config
 install:
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sudo softwareupdate -i "Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4"; fi
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew cask uninstall --force oclint; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
             - g++-5
       env:
         - GRCOV_CXX=g++-5
+        - GRCOV_GCOV=gcov-5
         - GRCOV_CLANG_CXX=clang++-7
         - GRCOV_LLVM_CONFIG=llvm-config-7
 
@@ -33,6 +34,7 @@ matrix:
             - g++-5
       env:
         - GRCOV_CXX=g++-5
+        - GRCOV_GCOV=gcov-5
         - GRCOV_CLANG_CXX=clang++-8
         - GRCOV_LLVM_CONFIG=llvm-config-8
 
@@ -50,6 +52,7 @@ matrix:
             - g++-5
       env:
         - GRCOV_CXX=g++-5
+        - GRCOV_GCOV=gcov-5
         - GRCOV_CLANG_CXX=clang++-7
         - GRCOV_LLVM_CONFIG=llvm-config-7
 
@@ -67,6 +70,7 @@ matrix:
             - g++-6
       env:
         - GRCOV_CXX=g++-6
+        - GRCOV_GCOV=gcov-6
         - GRCOV_CLANG_CXX=clang++-7
         - GRCOV_LLVM_CONFIG=llvm-config-7
 
@@ -84,6 +88,7 @@ matrix:
             - g++-7
       env:
         - GRCOV_CXX=g++-7
+        - GRCOV_GCOV=gcov-7
         - GRCOV_CLANG_CXX=clang++-7
         - GRCOV_LLVM_CONFIG=llvm-config-7
 
@@ -91,6 +96,7 @@ matrix:
       rust: nightly
       env:
         - GRCOV_CXX=g++-7
+        - GRCOV_GCOV=gcov-7
         - GRCOV_CLANG_CXX=clang++-7
         - GRCOV_LLVM_CONFIG=llvm-config-7
 install:
@@ -101,6 +107,7 @@ install:
 script:
     - export CXX=$GRCOV_CXX
     - $CXX --version
+    - $GRCOV_GCOV --version
     - $GRCOV_CLANG_CXX --version
     - if [ -z "$TRAVIS_TAG" ]; then cargo build --verbose; fi
     - if [ -z "$TRAVIS_TAG" ]; then cargo test -- --nocapture; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,11 @@ matrix:
           packages:
             - llvm-7-dev
             - clang-7
-            - llvm-7
-            - gcc-5
             - g++-5
       env:
-        - GCC_VER=5
-        - LLVM_VER=7
+        - GRCOV_GPP=g++-5
+        - GRCOV_CLANGPP=clang++-7
+        - GRCOV_LLVM_CONFIG=llvm-config-7
 
     - os: linux
       rust: stable
@@ -31,12 +30,11 @@ matrix:
           packages:
             - llvm-dev
             - clang
-            - llvm
-            - gcc-5
             - g++-5
       env:
-        - GCC_VER=5
-        - LLVM_VER=8
+        - GRCOV_CXX=g++-5
+        - GRCOV_CLANG_CXX=clang++-8
+        - GRCOV_LLVM_CONFIG=llvm-config-8
 
     - os: linux
       rust: nightly
@@ -49,12 +47,11 @@ matrix:
           packages:
             - llvm-7-dev
             - clang-7
-            - llvm-7
-            - gcc-5
             - g++-5
       env:
-        - GCC_VER=5
-        - LLVM_VER=7
+        - GRCOV_CXX=g++-5
+        - GRCOV_CLANG_CXX=clang++-7
+        - GRCOV_LLVM_CONFIG=llvm-config-7
 
     - os: linux
       rust: nightly
@@ -67,12 +64,11 @@ matrix:
           packages:
             - llvm-7-dev
             - clang-7
-            - llvm-7
-            - gcc-6
             - g++-6
       env:
-        - GCC_VER=6
-        - LLVM_VER=7
+        - GRCOV_CXX=g++-6
+        - GRCOV_CLANG_CXX=clang++-7
+        - GRCOV_LLVM_CONFIG=llvm-config-7
 
     - os: linux
       rust: nightly
@@ -85,35 +81,27 @@ matrix:
           packages:
             - llvm-7-dev
             - clang-7
-            - llvm-7
-            - gcc-7
             - g++-7
       env:
-        - GCC_VER=7
-        - LLVM_VER=7
+        - GRCOV_CXX=g++-7
+        - GRCOV_CLANG_CXX=clang++-7
+        - GRCOV_LLVM_CONFIG=llvm-config-7
 
     - os: osx
       rust: nightly
       env:
-        - GCC_VER=7
-        - LLVM_VER=7
+        - GRCOV_CXX=g++-7
+        - GRCOV_CLANG_CXX=clang++-7
+        - GRCOV_LLVM_CONFIG=llvm-config-7
 install:
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sudo softwareupdate -i "Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4"; fi
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew cask uninstall --force oclint; fi
-    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install gcc@${GCC_VER}; fi
+    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install gcc@7; fi
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install llvm@7 && brew link --overwrite --force llvm@7; fi
-    - mkdir -p symlinks
-    - ln -s `which clang-${LLVM_VER}` symlinks/clang
-    - ln -s `which clang++-${LLVM_VER}` symlinks/clang++
-    - ln -s `which llvm-cov-${LLVM_VER}` symlinks/llvm-cov
-    - ln -s `which llvm-config-${LLVM_VER}` symlinks/llvm-config
-    - ln -s `which gcc-${GCC_VER}` symlinks/gcc
-    - ln -s `which g++-${GCC_VER}` symlinks/g++
-    - ln -s `which gcov-${GCC_VER}` symlinks/gcov
 script:
-    - export PATH=$PWD/symlinks:$PATH
-    - gcc --version
-    - clang --version
+    - export CXX=$GRCOV_CXX
+    - $CXX --version
+    - $GRCOV_CLANG_CXX --version
     - if [ -z "$TRAVIS_TAG" ]; then cargo build --verbose; fi
     - if [ -z "$TRAVIS_TAG" ]; then cargo test -- --nocapture; fi
 before_deploy:
@@ -126,6 +114,6 @@ deploy:
   on:
     rust: nightly
     tags: true
-    condition: $GCC_VER = 7
+    condition: $GRCOV_CXX = g++-7
   provider: releases
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,8 +105,7 @@ install:
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install gcc@7; fi
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install llvm@7 && brew link --overwrite --force llvm@7; fi
 script:
-    - export CXX=$GRCOV_CXX
-    - export CC=$GRCOV_CXX
+    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export CXX=GRCOV_CLANG_CXX; else export CXX=GRCOV_CXX; fi
     - $CXX --version
     - $GRCOV_GCOV --version
     - $GRCOV_CLANG_CXX --version

--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,7 @@ use std::env;
 use std::process::Command;
 
 fn llvm_config(args: &[&str]) -> String {
-    let llvm_config_path = match env::var("GRCOV_LLVM_CONFIG") {
+    let llvm_config_path = match env::var("LLVM_CONFIG") {
         Ok(v) => v,
         Err(_e) => "llvm-config".to_string(),
     };

--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,7 @@ use std::env;
 use std::process::Command;
 
 fn llvm_config(args: &[&str]) -> String {
-    let llvm_config_path = match env::var("LLVM_CONFIG") {
+    let llvm_config_path = match env::var("GRCOV_LLVM_CONFIG") {
         Ok(v) => v,
         Err(_e) => "llvm-config".to_string(),
     };

--- a/src/gcov.rs
+++ b/src/gcov.rs
@@ -35,7 +35,7 @@ fn prova() {
 }*/
 
 fn get_gcov()-> String {
-    match env::var("GRCOV_GCOV") {
+    match env::var("GCOV") {
         Ok(s) => s,
         Err(_) => "gcov".to_string()
     }

--- a/src/gcov.rs
+++ b/src/gcov.rs
@@ -1,4 +1,5 @@
 use semver::Version;
+use std::env;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
@@ -33,8 +34,15 @@ fn prova() {
   println!("{:x}", gcov_read_unsigned());
 }*/
 
+fn get_gcov()-> String {
+    match env::var("GRCOV_GCOV") {
+        Ok(s) => s,
+        Err(_) => "gcov".to_string()
+    }
+}
+
 pub fn run_gcov(gcno_path: &PathBuf, branch_enabled: bool, working_dir: &PathBuf) {
-    let mut command = Command::new("gcov");
+    let mut command = Command::new(&get_gcov());
     let command = if branch_enabled {
         command.arg("-b").arg("-c")
     } else {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -16,8 +16,8 @@ use walkdir::WalkDir;
 use zip::write::FileOptions;
 use zip::ZipWriter;
 
-fn get_tool(env: &str, default: &str) -> String {
-    match env::var("GRCOV_".to_owned() + env) {
+fn get_tool(name: &str, default: &str) -> String {
+    match env::var(name) {
         Ok(s) => s,
         Err(_) => default.to_string()
     }
@@ -435,7 +435,7 @@ fn test_integration() {
 
             if cfg!(target_os = "linux") {
                 println!("GCC");
-                let gpp = &get_tool("CXX", "g++");
+                let gpp = &get_tool("GCC_CXX", "g++");
                 let gcc_version = get_version(gpp);
                 make(path, gpp);
                 run(path);
@@ -479,7 +479,7 @@ fn test_integration() {
 
 #[test]
 fn test_integration_zip_zip() {
-    let compilers = vec![get_tool("CXX", "g++"), get_tool("CLANG_CXX", "clang++")];
+    let compilers = vec![get_tool("GCC_CXX", "g++"), get_tool("CLANG_CXX", "clang++")];
 
     for compiler in compilers {
         let is_llvm = compiler.contains("clang");
@@ -564,7 +564,7 @@ fn test_integration_zip_zip() {
 
 #[test]
 fn test_integration_zip_dir() {
-    let compilers = vec![get_tool("CXX", "g++"), get_tool("CLANG_CXX", "clang++")];
+    let compilers = vec![get_tool("GCC_CXX", "g++"), get_tool("CLANG_CXX", "clang++")];
 
     for compiler in compilers {
         let is_llvm = compiler.contains("clang");

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -435,7 +435,7 @@ fn test_integration() {
 
             if !cfg!(windows) {
                 println!("GCC");
-                let gpp = &get_tool("GPP", "g++");
+                let gpp = &get_tool("CXX", "g++");
                 let gcc_version = get_version(gpp);
                 make(path, gpp);
                 run(path);
@@ -453,7 +453,7 @@ fn test_integration() {
 
             println!("\nLLVM");
             let llvm_version = get_version(&get_tool("LLVM_CONFIG", "llvm-config"));
-            let clangpp = &get_tool("CLANGPP", "clang++");
+            let clangpp = &get_tool("CLANG_CXX", "clang++");
             let clang_version = get_version(clangpp);
             assert_eq!(
                 llvm_version, clang_version,
@@ -479,10 +479,10 @@ fn test_integration() {
 
 #[test]
 fn test_integration_zip_zip() {
-    let compilers = vec![get_tool("GPP", "g++"), get_tool("CLANGPP", "clang++")];
+    let compilers = vec![get_tool("CXX", "g++"), get_tool("CLANG_CXX", "clang++")];
 
     for compiler in compilers {
-        let is_llvm = compiler.starts_with("clang++");
+        let is_llvm = compiler.contains("clang");
 
         if cfg!(windows) && !is_llvm {
             continue;
@@ -564,10 +564,10 @@ fn test_integration_zip_zip() {
 
 #[test]
 fn test_integration_zip_dir() {
-    let compilers = vec![get_tool("GPP", "g++"), get_tool("CLANGPP", "clang++")];
+    let compilers = vec![get_tool("CXX", "g++"), get_tool("CLANG_CXX", "clang++")];
 
     for compiler in compilers {
-        let is_llvm = compiler.starts_with("clang++");
+        let is_llvm = compiler.contains("clang");
 
         if cfg!(windows) && !is_llvm {
             continue;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -433,7 +433,7 @@ fn test_integration() {
 
             do_clean(path);
 
-            if !cfg!(windows) {
+            if !cfg!(windows) && !cfg!(macos) {
                 println!("GCC");
                 let gpp = &get_tool("CXX", "g++");
                 let gcc_version = get_version(gpp);
@@ -484,7 +484,7 @@ fn test_integration_zip_zip() {
     for compiler in compilers {
         let is_llvm = compiler.contains("clang");
 
-        if cfg!(windows) && !is_llvm {
+        if (cfg!(windows) || cfg!(macos)) && !is_llvm {
             continue;
         }
 
@@ -569,7 +569,7 @@ fn test_integration_zip_dir() {
     for compiler in compilers {
         let is_llvm = compiler.contains("clang");
 
-        if cfg!(windows) && !is_llvm {
+        if (cfg!(windows) || cfg!(macos)) && !is_llvm {
             continue;
         }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -433,7 +433,7 @@ fn test_integration() {
 
             do_clean(path);
 
-            if !cfg!(windows) && !cfg!(macos) {
+            if cfg!(target_os = "linux") {
                 println!("GCC");
                 let gpp = &get_tool("CXX", "g++");
                 let gcc_version = get_version(gpp);
@@ -484,7 +484,7 @@ fn test_integration_zip_zip() {
     for compiler in compilers {
         let is_llvm = compiler.contains("clang");
 
-        if (cfg!(windows) || cfg!(macos)) && !is_llvm {
+        if !cfg!(target_os = "linux") && !is_llvm {
             continue;
         }
 
@@ -569,7 +569,7 @@ fn test_integration_zip_dir() {
     for compiler in compilers {
         let is_llvm = compiler.contains("clang");
 
-        if (cfg!(windows) || cfg!(macos)) && !is_llvm {
+        if !cfg!(target_os = "linux") && !is_llvm {
             continue;
         }
 


### PR DESCRIPTION
When having several compilers, it's a pain to have to make symliks to select the correct one.
So with this patch we can easily select the good tools, e.g. "GRCOV_CXX=g++-7 GRCOV_GCOV=gcov-7 cargo test" will run tests with g++-7 instead of 8 which the default for g++ on my machine.