### PR TITLE
Revert "Don't build on Appveyor/Travis when changing Travis/Appveyor configuration"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,15 +103,7 @@ matrix:
         - CLANG_CXX=clang++
         - LLVM_CONFIG=llvm-config
         - DEPLOY=1
-before_install:
-- |
-    if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-      TRAVIS_COMMIT_RANGE="FETCH_HEAD...$TRAVIS_BRANCH"
-    fi
-    git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(appveyor.yml)' || {
-      echo "Only appveyor.yml was updated, stopping build process."
-      exit 
-    } 
+
 install:
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sudo softwareupdate -i "Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4"; fi
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew cask uninstall --force oclint; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,10 +2,6 @@ image: Visual Studio 2017
 platform:
 - x64
 
-skip_commits:
-  files:
-    - .travis.yml
-
 environment:
   matrix:
     - CHANNEL: stable


### PR DESCRIPTION
Reverts mozilla/grcov#218

Unfortunately it didn't work correctly, Travis builds are skipped even when other files are modified.