### PR TITLE
Don't run travis CI when modifying appveyor.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,11 +104,15 @@ matrix:
         - LLVM_CONFIG=llvm-config
         - DEPLOY=1
 before_install:
+    - echo $TRAVIS_BRANCH
+    - echo $TRAVIS_COMMIT_RANGE
     - |
       if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
         TRAVIS_COMMIT_RANGE="FETCH_HEAD...$TRAVIS_BRANCH"
+        echo $TRAVIS_COMMIT_RANGE
       fi
       git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(appveyor.yml)' || {
+        echo $(git diff --name-only $TRAVIS_COMMIT_RANGE)
         echo "Only appveyor.yml was updated, stopping build process."
         exit
       }

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,15 +104,7 @@ matrix:
         - LLVM_CONFIG=llvm-config
         - DEPLOY=1
 before_install:
-    - echo $TRAVIS_BRANCH
-    - echo $TRAVIS_COMMIT_RANGE
-    - |
-      if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-        TRAVIS_COMMIT_RANGE="FETCH_HEAD...$TRAVIS_BRANCH"
-        echo $TRAVIS_COMMIT_RANGE
-      fi
-      git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(appveyor.yml)' || {
-        echo $(git diff --name-only $TRAVIS_COMMIT_RANGE)
+      git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '^appveyor.yml$' || {
         echo "Only appveyor.yml was updated, stopping build process."
         exit
       }

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,14 +104,14 @@ matrix:
         - LLVM_CONFIG=llvm-config
         - DEPLOY=1
 before_install:
-- |
-    if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-      TRAVIS_COMMIT_RANGE="FETCH_HEAD...$TRAVIS_BRANCH"
-    fi
-    git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(appveyor.yml)' || {
-      echo "Only appveyor.yml was updated, stopping build process."
-      exit 
-    } 
+    - |
+      if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+        TRAVIS_COMMIT_RANGE="FETCH_HEAD...$TRAVIS_BRANCH"
+      fi
+      git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(appveyor.yml)' || {
+        echo "Only appveyor.yml was updated, stopping build process."
+        exit
+      }
 install:
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sudo softwareupdate -i "Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4"; fi
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew cask uninstall --force oclint; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,15 @@ matrix:
         - CLANG_CXX=clang++
         - LLVM_CONFIG=llvm-config
         - DEPLOY=1
-
+before_install:
+- |
+    if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+      TRAVIS_COMMIT_RANGE="FETCH_HEAD...$TRAVIS_BRANCH"
+    fi
+    git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(appveyor.yml)' || {
+      echo "Only appveyor.yml was updated, stopping build process."
+      exit 
+    } 
 install:
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sudo softwareupdate -i "Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4"; fi
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew cask uninstall --force oclint; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,6 +104,7 @@ matrix:
         - LLVM_CONFIG=llvm-config
         - DEPLOY=1
 before_install:
+    - |
       git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '^appveyor.yml$' || {
         echo "Only appveyor.yml was updated, stopping build process."
         exit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,10 @@ image: Visual Studio 2017
 platform:
 - x64
 
+skip_commits:
+  files:
+    - .travis.yml
+
 environment:
   matrix:
     - CHANNEL: stable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,23 @@
 extern crate crypto;
 #[macro_use]
 extern crate serde_json;
+
 extern crate crossbeam;
+
 extern crate globset;
+
 extern crate libc;
+
 extern crate semver;
+
 extern crate tempdir;
+
 extern crate uuid;
+
 extern crate walkdir;
+
 extern crate xml;
+
 extern crate zip;
 
 mod defs;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,23 +1,14 @@
 extern crate crypto;
 #[macro_use]
 extern crate serde_json;
-
 extern crate crossbeam;
-
 extern crate globset;
-
 extern crate libc;
-
 extern crate semver;
-
 extern crate tempdir;
-
 extern crate uuid;
-
 extern crate walkdir;
-
 extern crate xml;
-
 extern crate zip;
 
 mod defs;


### PR DESCRIPTION
For #207.

So the issue was that the commit range was turning into `FETCH_HEAD...master`. The behaviour for running `git diff` with two endpoints separated by `...` is specified [here](https://git-scm.com/docs/git-diff#git-diff-emgitdiffemltoptionsgtltcommitgtltcommitgt--ltpathgt82308203). The important part is that it deals with differences up to the second endpoint, in this case `master`, which means there were no file changes. You can see this in [travis where there is an empty line](https://travis-ci.org/mozilla/grcov/jobs/457169018#L697).

I think the original PR for fb should have had `$TRAVIS_BRANCH..FETCH_HEAD` or `$TRAVIS_BRANCH...FETCH_HEAD` instead of `FETCH_HEAD...$TRAVIS_BRANCH` which makes almost no sense because a pr will almost always be ahead of the target branch.

Also, the modification to the `TRAVIS_COMMIT_RANGE` environment variable was unnecessary once travis-ci/travis-core#383 was merged.