### PR TITLE
Remove ignored dirs from file_to_path in path_rewriting

### DIFF
--- a/src/path_rewriting.rs
+++ b/src/path_rewriting.rs
@@ -208,10 +208,12 @@ pub fn rewrite_paths(
                 continue;
             }
 
-            let name = entry.file_name().to_str().unwrap().to_string();
-
             let path = full_path.strip_prefix(&source_dir).unwrap().to_path_buf();
+            if to_ignore_globset.is_match(&path) {
+                continue;
+            }
 
+            let name = entry.file_name().to_str().unwrap().to_string();
             match file_to_paths.entry(name) {
                 hash_map::Entry::Occupied(f) => f.into_mut().push(path),
                 hash_map::Entry::Vacant(v) => {


### PR DESCRIPTION
The use case:
 - we've foo/src/main.rs
 - we've foo/bar/src/main.rs
because bar project lives within foo project.
So when getting ccov for foo, we've an error because we've 2 possibilities for src/main.rs.
So the idea is to add --ignore-dirs "bar/*" and so avoid the conflict.  