### PR TITLE
Added -o flag to output to file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,6 @@ use std::fs::{self, File};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::{env, process, thread};
-use std::option::Option;
 
 #[global_allocator]
 static GLOBAL: System = System;
@@ -65,7 +64,7 @@ fn main() {
     let mut path_mapping_file = "";
     let mut filter_option = None;
     let mut num_threads = num_cpus::get() * 2;
-    let mut output_file_path: Option<&str> = None;
+    let mut output_file_path = None;
 
     while i < args.len() {
         if args[i] == "-t" {
@@ -200,9 +199,7 @@ fn main() {
                 print_usage(&args[0]);
                 process::exit(1);
             }
-            if &args[i + 1] != "-"{
-                output_file_path = Some(&args[i + 1]);
-            }
+            output_file_path = Some(&args[i + 1]);
             i += 1;
         } else {
             paths.push(args[i].clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use std::fs::{self, File};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::{env, process, thread};
+use std::option::Option;
 
 #[global_allocator]
 static GLOBAL: System = System;
@@ -64,7 +65,7 @@ fn main() {
     let mut path_mapping_file = "";
     let mut filter_option = None;
     let mut num_threads = num_cpus::get() * 2;
-    let mut output_file_path = "-";
+    let mut output_file_path: Option<&str> = None;
 
     while i < args.len() {
         if args[i] == "-t" {
@@ -199,7 +200,9 @@ fn main() {
                 print_usage(&args[0]);
                 process::exit(1);
             }
-            output_file_path = &args[i + 1];
+            if &args[i + 1] != "-"{
+                output_file_path = Some(&args[i + 1]);
+            }
             i += 1;
         } else {
             paths.push(args[i].clone());

--- a/src/output.rs
+++ b/src/output.rs
@@ -8,7 +8,7 @@ extern crate md5;
 
 use defs::*;
 
-fn get_target_output_writable(output_file: Option<&str>) -> Box<Write> {
+fn get_target_output_writable(output_file: Option<&String>) -> Box<Write> {
     let write_target: Box<Write> = match output_file {
         Some(filename) => {
             Box::new(File::create(filename).unwrap())
@@ -21,7 +21,7 @@ fn get_target_output_writable(output_file: Option<&str>) -> Box<Write> {
     return write_target;
 }
 
-pub fn output_activedata_etl(results: CovResultIter, output_file: Option<&str>) {
+pub fn output_activedata_etl(results: CovResultIter, output_file: Option<&String>) {
 
     let mut writer = BufWriter::new(get_target_output_writable(output_file));
 
@@ -132,7 +132,7 @@ pub fn output_activedata_etl(results: CovResultIter, output_file: Option<&str>) 
     }
 }
 
-pub fn output_lcov(results: CovResultIter, output_file: Option<&str>) {
+pub fn output_lcov(results: CovResultIter, output_file: Option<&String>) {
     let mut writer = BufWriter::new(get_target_output_writable(output_file));
     writer.write_all(b"TN:\n").unwrap();
 
@@ -213,7 +213,7 @@ pub fn output_coveralls(
     service_job_number: &str,
     commit_sha: &str,
     with_function_info: bool,
-    output_file: Option<&str>
+    output_file: Option<&String>
 ) {
     let mut source_files = Vec::new();
 
@@ -286,7 +286,7 @@ pub fn output_coveralls(
     ).unwrap();
 }
 
-pub fn output_files(results: CovResultIter, output_file: Option<&str>) {
+pub fn output_files(results: CovResultIter, output_file: Option<&String>) {
 
     let mut writer = BufWriter::new(get_target_output_writable(output_file));
     for (_, rel_path, _) in results {

--- a/src/output.rs
+++ b/src/output.rs
@@ -8,20 +8,20 @@ extern crate md5;
 
 use defs::*;
 
-fn get_target_output_writable(output_file: &str) -> Box<Write> {
+fn get_target_output_writable(output_file: Option<&str>) -> Box<Write> {
     let write_target: Box<Write> = match output_file {
-        "-" => {
+        Some(filename) => {
+            Box::new(File::create(filename).unwrap())
+        },
+        None => {
             let stdout = io::stdout();
             Box::new(stdout)
         },
-        _ => {
-            Box::new(File::create(output_file).unwrap())
-        }
     };
     return write_target;
 }
 
-pub fn output_activedata_etl(results: CovResultIter, output_file: &str) {
+pub fn output_activedata_etl(results: CovResultIter, output_file: Option<&str>) {
 
     let mut writer = BufWriter::new(get_target_output_writable(output_file));
 
@@ -132,7 +132,7 @@ pub fn output_activedata_etl(results: CovResultIter, output_file: &str) {
     }
 }
 
-pub fn output_lcov(results: CovResultIter, output_file: &str) {
+pub fn output_lcov(results: CovResultIter, output_file: Option<&str>) {
     let mut writer = BufWriter::new(get_target_output_writable(output_file));
     writer.write_all(b"TN:\n").unwrap();
 
@@ -213,7 +213,7 @@ pub fn output_coveralls(
     service_job_number: &str,
     commit_sha: &str,
     with_function_info: bool,
-    output_file: &str
+    output_file: Option<&str>
 ) {
     let mut source_files = Vec::new();
 
@@ -286,7 +286,7 @@ pub fn output_coveralls(
     ).unwrap();
 }
 
-pub fn output_files(results: CovResultIter, output_file: &str) {
+pub fn output_files(results: CovResultIter, output_file: Option<&str>) {
 
     let mut writer = BufWriter::new(get_target_output_writable(output_file));
     for (_, rel_path, _) in results {

--- a/src/output.rs
+++ b/src/output.rs
@@ -8,9 +8,22 @@ extern crate md5;
 
 use defs::*;
 
-pub fn output_activedata_etl(results: CovResultIter) {
-    let stdout = io::stdout();
-    let mut writer = BufWriter::new(stdout.lock());
+fn get_target_output_writable(output_file: &str) -> Box<Write> {
+    let write_target: Box<Write> = match output_file {
+        "-" => {
+            let stdout = io::stdout();
+            Box::new(stdout)
+        },
+        _ => {
+            Box::new(File::create(output_file).unwrap())
+        }
+    };
+    return write_target;
+}
+
+pub fn output_activedata_etl(results: CovResultIter, output_file: &str) {
+
+    let mut writer = BufWriter::new(get_target_output_writable(output_file));
 
     for (_, rel_path, result) in results {
         let covered: Vec<u32> = result
@@ -119,10 +132,8 @@ pub fn output_activedata_etl(results: CovResultIter) {
     }
 }
 
-pub fn output_lcov(results: CovResultIter) {
-    let stdout = io::stdout();
-    let mut writer = BufWriter::new(stdout.lock());
-
+pub fn output_lcov(results: CovResultIter, output_file: &str) {
+    let mut writer = BufWriter::new(get_target_output_writable(output_file));
     writer.write_all(b"TN:\n").unwrap();
 
     for (_, rel_path, result) in results {
@@ -202,6 +213,7 @@ pub fn output_coveralls(
     service_job_number: &str,
     commit_sha: &str,
     with_function_info: bool,
+    output_file: &str
 ) {
     let mut source_files = Vec::new();
 
@@ -255,10 +267,9 @@ pub fn output_coveralls(
         }
     }
 
-    let stdout = io::stdout();
-    let mut stdout = stdout.lock();
+    let mut writer = BufWriter::new(get_target_output_writable(output_file));
     serde_json::to_writer(
-        &mut stdout,
+        &mut writer,
         &json!({
         "repo_token": repo_token,
         "git": {
@@ -275,10 +286,9 @@ pub fn output_coveralls(
     ).unwrap();
 }
 
-pub fn output_files(results: CovResultIter) {
-    let stdout = io::stdout();
-    let mut writer = BufWriter::new(stdout.lock());
+pub fn output_files(results: CovResultIter, output_file: &str) {
 
+    let mut writer = BufWriter::new(get_target_output_writable(output_file));
     for (_, rel_path, _) in results {
         writeln!(writer, "{}", rel_path.display()).unwrap();
     }


### PR DESCRIPTION
Fixes #208.

Passes `cargo test` on multiple passes.

A notable change is that in this implementation the functions in `output.rs` no longer lock stdout for the entire duration from the start, instead writing to stdout normally without an explicit lock. I believe this is fine because the function that is called is the only thing that actually writes to output.