### PR TITLE
Implement alias for commonly used variable types

### DIFF
--- a/benches/filter.rs
+++ b/benches/filter.rs
@@ -3,13 +3,13 @@ extern crate grcov;
 extern crate rustc_hash;
 extern crate test;
 
-use grcov::{CovResult, Function};
+use grcov::{CovResult, Function, FunctionMap};
 use rustc_hash::FxHashMap;
 use test::{black_box, Bencher};
 
 #[bench]
 fn bench_filter_covered(b: &mut Bencher) {
-    let mut functions: FxHashMap<String, Function> = FxHashMap::default();
+    let mut functions: FunctionMap = FxHashMap::default();
     functions.insert(
         "f1".to_string(),
         Function {
@@ -44,7 +44,7 @@ fn bench_filter_covered_no_functions(b: &mut Bencher) {
 
 #[bench]
 fn bench_filter_uncovered_no_lines_executed(b: &mut Bencher) {
-    let mut functions: FxHashMap<String, Function> = FxHashMap::default();
+    let mut functions: FunctionMap = FxHashMap::default();
     functions.insert(
         "f1".to_string(),
         Function {
@@ -69,7 +69,7 @@ fn bench_filter_uncovered_no_lines_executed(b: &mut Bencher) {
 
 #[bench]
 fn bench_filter_covered_functions_executed(b: &mut Bencher) {
-    let mut functions: FxHashMap<String, Function> = FxHashMap::default();
+    let mut functions: FunctionMap = FxHashMap::default();
     functions.insert(
         "top-level".to_string(),
         Function {
@@ -94,7 +94,7 @@ fn bench_filter_covered_functions_executed(b: &mut Bencher) {
 
 #[bench]
 fn bench_filter_covered_toplevel_executed(b: &mut Bencher) {
-    let mut functions: FxHashMap<String, Function> = FxHashMap::default();
+    let mut functions: FunctionMap = FxHashMap::default();
     functions.insert(
         "top-level".to_string(),
         Function {
@@ -112,7 +112,7 @@ fn bench_filter_covered_toplevel_executed(b: &mut Bencher) {
 
 #[bench]
 fn bench_filter_uncovered_functions_not_executed(b: &mut Bencher) {
-    let mut functions: FxHashMap<String, Function> = FxHashMap::default();
+    let mut functions: FunctionMap = FxHashMap::default();
     functions.insert(
         "top-level".to_string(),
         Function {

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -5,7 +5,7 @@ extern crate rustc_hash;
 extern crate test;
 
 use crossbeam::crossbeam_channel::unbounded;
-use grcov::{CovResult, Function};
+use grcov::{CovResult, Function, FunctionMap};
 use rustc_hash::FxHashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -16,7 +16,7 @@ use grcov::*;
 
 #[bench]
 fn bench_lib_merge_results(b: &mut Bencher) {
-    let mut functions1: FxHashMap<String, Function> = FxHashMap::default();
+    let mut functions1: FunctionMap = FxHashMap::default();
     functions1.insert(
         "f1".to_string(),
         Function {
@@ -44,7 +44,7 @@ fn bench_lib_merge_results(b: &mut Bencher) {
         functions: functions1,
     };
 
-    let mut functions2: FxHashMap<String, Function> = FxHashMap::default();
+    let mut functions2: FunctionMap = FxHashMap::default();
     functions2.insert(
         "f1".to_string(),
         Function {

--- a/src/defs.rs
+++ b/src/defs.rs
@@ -48,6 +48,8 @@ pub struct WorkItem {
     pub name: String,
 }
 
+pub type FunctionMap = FxHashMap<String, Function>;
+
 pub type JobReceiver = Receiver<Option<WorkItem>>;
 pub type JobSender = Sender<Option<WorkItem>>;
 

--- a/src/defs.rs
+++ b/src/defs.rs
@@ -16,7 +16,7 @@ pub struct Function {
 pub struct CovResult {
     pub lines: BTreeMap<u32, u64>,
     pub branches: BTreeMap<u32, Vec<bool>>,
-    pub functions: FxHashMap<String, Function>,
+    pub functions: FunctionMap,
 }
 
 #[derive(Debug, PartialEq, Copy, Clone)]

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -27,7 +27,7 @@ mod tests {
 
     #[test]
     fn test_covered() {
-        let mut functions: FxHashMap<String, Function> = FxHashMap::default();
+        let mut functions: FunctionMap = FxHashMap::default();
         functions.insert(
             "f1".to_string(),
             Function {
@@ -64,7 +64,7 @@ mod tests {
 
     #[test]
     fn test_uncovered_no_lines_executed() {
-        let mut functions: FxHashMap<String, Function> = FxHashMap::default();
+        let mut functions: FunctionMap = FxHashMap::default();
         functions.insert(
             "f1".to_string(),
             Function {
@@ -90,7 +90,7 @@ mod tests {
 
     #[test]
     fn test_covered_functions_executed() {
-        let mut functions: FxHashMap<String, Function> = FxHashMap::default();
+        let mut functions: FunctionMap = FxHashMap::default();
         functions.insert(
             "top-level".to_string(),
             Function {
@@ -116,7 +116,7 @@ mod tests {
 
     #[test]
     fn test_covered_toplevel_executed() {
-        let mut functions: FxHashMap<String, Function> = FxHashMap::default();
+        let mut functions: FunctionMap = FxHashMap::default();
         functions.insert(
             "top-level".to_string(),
             Function {
@@ -135,7 +135,7 @@ mod tests {
 
     #[test]
     fn test_uncovered_functions_not_executed() {
-        let mut functions: FxHashMap<String, Function> = FxHashMap::default();
+        let mut functions: FunctionMap = FxHashMap::default();
         functions.insert(
             "top-level".to_string(),
             Function {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,7 +236,7 @@ mod tests {
 
     #[test]
     fn test_merge_results() {
-        let mut functions1: FxHashMap<String, Function> = FxHashMap::default();
+        let mut functions1: FunctionMap = FxHashMap::default();
         functions1.insert(
             "f1".to_string(),
             Function {
@@ -263,7 +263,7 @@ mod tests {
             .collect(),
             functions: functions1,
         };
-        let mut functions2: FxHashMap<String, Function> = FxHashMap::default();
+        let mut functions2: FunctionMap = FxHashMap::default();
         functions2.insert(
             "f1".to_string(),
             Function {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -402,8 +402,8 @@ fn parse_jacoco_report_method<T: Read>(
 fn parse_jacoco_report_class<T: Read>(
     parser: &mut EventReader<T>,
     class_name: &str,
-) -> Result<FxHashMap<String, Function>, ParserError> {
-    let mut functions: FxHashMap<String, Function> = FxHashMap::default();
+) -> Result<FunctionMap, ParserError> {
+    let mut functions: FunctionMap = FxHashMap::default();
 
     loop {
         match parser.next() {
@@ -1502,7 +1502,7 @@ mod tests {
         lines.insert(1, 0);
         lines.insert(4, 1);
         lines.insert(6, 1);
-        let mut functions: FxHashMap<String, Function> = FxHashMap::default();
+        let mut functions: FunctionMap = FxHashMap::default();
         functions.insert(
             String::from("hello#<init>"),
             Function {
@@ -1541,7 +1541,7 @@ mod tests {
         for i in vec![5, 10, 14, 15, 18, 22, 23, 25, 27, 31, 34, 37, 44, 49] {
             lines.insert(i, 0);
         }
-        let mut functions: FxHashMap<String, Function> = FxHashMap::default();
+        let mut functions: FunctionMap = FxHashMap::default();
 
         for (name, start, executed) in vec![
             ("Person$InnerClassForPerson#getSomethingElse", 31, false),

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -956,7 +956,8 @@ impl GcovFunction {
 #[cfg(test)]
 mod tests {
 
-    use super::*;
+use crate::defs::FunctionMap;
+use super::*;
 
     fn get_input_string(path: &str) -> String {
         let path = PathBuf::from(path);
@@ -1081,7 +1082,7 @@ mod tests {
 
         let mut lines: BTreeMap<u32, u64> = BTreeMap::new();
         lines.insert(2, 1);
-        let mut functions: FxHashMap<String, Function> = FxHashMap::default();
+        let mut functions: FunctionMap = FxHashMap::default();
         functions.insert(
             String::from("main"),
             Function {
@@ -1137,7 +1138,7 @@ mod tests {
             lines.insert(x.0, x.1);
         });
 
-        let mut functions: FxHashMap<String, Function> = FxHashMap::default();
+        let mut functions: FunctionMap = FxHashMap::default();
         functions.insert(
             String::from("foo"),
             Function {


### PR DESCRIPTION
Fixes: #281 

### Summary of Changes
* Created and used alias for FxHashMap<String, Function>

I created this type alias because it was the one that was mostly changed during my PR (#252). I will look into the code base for commonly used types and will update the PR as I do so.