### PR TITLE
Update README.md to use new version in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Here is an example of .travis.yml file
 language: rust
 
 before_install:
-  - curl -L https://github.com/mozilla/grcov/releases/download/v0.5.1/grcov-linux-x86_64.tar.bz2 | tar jxf -
+  - curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-linux-x86_64.tar.bz2 | tar jxf -
 
 matrix:
   include:

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Here is an example of .travis.yml file
 language: rust
 
 before_install:
-  - curl -L https://github.com/mozilla/grcov/releases/download/v0.4.1/grcov-linux-x86_64.tar.bz2 | tar jxf -
+  - curl -L https://github.com/mozilla/grcov/releases/download/v0.5.1/grcov-linux-x86_64.tar.bz2 | tar jxf -
 
 matrix:
   include:


### PR DESCRIPTION
When I copied & pasted the example to use grcov in my project, it failed in TravisCI, because it was `v0.4.1` and too old to use. To fix that, I updated README.