### PR TITLE
Chore/output bench

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -81,19 +81,20 @@ fn bench_lib_merge_results(b: &mut Bencher) {
 #[bench]
 fn bench_lib_consumer(b: &mut Bencher) {
     let num_threads = 2;
-    let result_map: Arc<SyncCovResultMap> = Arc::new(Mutex::new(FxHashMap::with_capacity_and_hasher(20_000, Default::default())));
+    let result_map: Arc<SyncCovResultMap> = Arc::new(Mutex::new(
+        FxHashMap::with_capacity_and_hasher(20_000, Default::default()),
+    ));
     let (sender, receiver) = unbounded();
     let source_root = None;
     let working_dir = PathBuf::from("");
     let gcno_buf: Vec<u8> = vec![
-        111, 110, 99, 103, 42, 50, 48, 52, 74, 200, 254, 66, 0, 0, 0, 1, 9, 0, 0, 0, 0, 0, 0,
-        0, 236, 217, 93, 255, 2, 0, 0, 0, 109, 97, 105, 110, 0, 0, 0, 0, 2, 0, 0, 0, 102, 105,
-        108, 101, 46, 99, 0, 0, 1, 0, 0, 0, 0, 0, 65, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 67, 1, 3, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 67, 1, 3,
-        0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 69, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 69, 1, 8, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 102,
-        105, 108, 101, 46, 99, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0,
+        111, 110, 99, 103, 42, 50, 48, 52, 74, 200, 254, 66, 0, 0, 0, 1, 9, 0, 0, 0, 0, 0, 0, 0,
+        236, 217, 93, 255, 2, 0, 0, 0, 109, 97, 105, 110, 0, 0, 0, 0, 2, 0, 0, 0, 102, 105, 108,
+        101, 46, 99, 0, 0, 1, 0, 0, 0, 0, 0, 65, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 67, 1, 3, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 67, 1, 3, 0, 0, 0, 1, 0,
+        0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 69, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 69, 1, 8, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 102, 105, 108, 101, 46, 99, 0,
+        0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ];
 
     b.iter(|| {
@@ -114,6 +115,7 @@ fn bench_lib_consumer(b: &mut Bencher) {
                         &result_map,
                         receiver,
                         false,
+                        false,
                     );
                 })
                 .unwrap();
@@ -122,18 +124,17 @@ fn bench_lib_consumer(b: &mut Bencher) {
         }
 
         for _ in 0..10_000 {
-            sender.send(Some(
-                WorkItem {
+            sender
+                .send(Some(WorkItem {
                     format: ItemFormat::GCNO,
-                    item: ItemType::Buffers(
-                        GcnoBuffers {
-                            stem: "".to_string(),
-                            gcno_buf: gcno_buf.clone(),
-                            gcda_buf: Vec::new(),
-                        }),
+                    item: ItemType::Buffers(GcnoBuffers {
+                        stem: "".to_string(),
+                        gcno_buf: gcno_buf.clone(),
+                        gcda_buf: Vec::new(),
+                    }),
                     name: "".to_string(),
-                })
-            ).unwrap();
+                }))
+                .unwrap();
         }
 
         for _ in 0..num_threads {

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -109,7 +109,14 @@ fn bench_lib_consumer(b: &mut Bencher) {
             let t = thread::Builder::new()
                 .name(format!("Consumer {}", i))
                 .spawn(move || {
-                    consumer(&working_dir, &source_root, &result_map, receiver, false);
+                    consumer(
+                        &working_dir,
+                        &source_root,
+                        &result_map,
+                        receiver,
+                        false,
+                        false,
+                    );
                 })
                 .unwrap();
 

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -81,20 +81,19 @@ fn bench_lib_merge_results(b: &mut Bencher) {
 #[bench]
 fn bench_lib_consumer(b: &mut Bencher) {
     let num_threads = 2;
-    let result_map: Arc<SyncCovResultMap> = Arc::new(Mutex::new(
-        FxHashMap::with_capacity_and_hasher(20_000, Default::default()),
-    ));
+    let result_map: Arc<SyncCovResultMap> = Arc::new(Mutex::new(FxHashMap::with_capacity_and_hasher(20_000, Default::default())));
     let (sender, receiver) = unbounded();
     let source_root = None;
     let working_dir = PathBuf::from("");
     let gcno_buf: Vec<u8> = vec![
-        111, 110, 99, 103, 42, 50, 48, 52, 74, 200, 254, 66, 0, 0, 0, 1, 9, 0, 0, 0, 0, 0, 0, 0,
-        236, 217, 93, 255, 2, 0, 0, 0, 109, 97, 105, 110, 0, 0, 0, 0, 2, 0, 0, 0, 102, 105, 108,
-        101, 46, 99, 0, 0, 1, 0, 0, 0, 0, 0, 65, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 67, 1, 3, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 67, 1, 3, 0, 0, 0, 1, 0,
-        0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 69, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 69, 1, 8, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 102, 105, 108, 101, 46, 99, 0,
-        0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        111, 110, 99, 103, 42, 50, 48, 52, 74, 200, 254, 66, 0, 0, 0, 1, 9, 0, 0, 0, 0, 0, 0,
+        0, 236, 217, 93, 255, 2, 0, 0, 0, 109, 97, 105, 110, 0, 0, 0, 0, 2, 0, 0, 0, 102, 105,
+        108, 101, 46, 99, 0, 0, 1, 0, 0, 0, 0, 0, 65, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 67, 1, 3, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 67, 1, 3,
+        0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 69, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 69, 1, 8, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 102,
+        105, 108, 101, 46, 99, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0,
     ];
 
     b.iter(|| {
@@ -115,7 +114,6 @@ fn bench_lib_consumer(b: &mut Bencher) {
                         &result_map,
                         receiver,
                         false,
-                        false,
                     );
                 })
                 .unwrap();
@@ -124,17 +122,18 @@ fn bench_lib_consumer(b: &mut Bencher) {
         }
 
         for _ in 0..10_000 {
-            sender
-                .send(Some(WorkItem {
+            sender.send(Some(
+                WorkItem {
                     format: ItemFormat::GCNO,
-                    item: ItemType::Buffers(GcnoBuffers {
-                        stem: "".to_string(),
-                        gcno_buf: gcno_buf.clone(),
-                        gcda_buf: Vec::new(),
-                    }),
+                    item: ItemType::Buffers(
+                        GcnoBuffers {
+                            stem: "".to_string(),
+                            gcno_buf: gcno_buf.clone(),
+                            gcda_buf: Vec::new(),
+                        }),
                     name: "".to_string(),
-                }))
-                .unwrap();
+                })
+            ).unwrap();
         }
 
         for _ in 0..num_threads {

--- a/benches/output.rs
+++ b/benches/output.rs
@@ -8,8 +8,8 @@ use grcov::{
     FunctionMap,
 };
 use rustc_hash::FxHashMap;
-use std::fs::remove_file;
 use std::path::PathBuf;
+use tempfile::tempdir;
 use test::{black_box, Bencher};
 
 fn generate_cov_result_iter() -> CovResultIter {
@@ -48,27 +48,33 @@ fn generate_cov_result_iter() -> CovResultIter {
 }
 #[bench]
 fn bench_output_activedata_etl(b: &mut Bencher) {
+    let dir = tempdir().unwrap();
     b.iter(|| {
         black_box(output_activedata_etl(
             generate_cov_result_iter(),
-            Some("./temp"),
+            Some(dir.path().join("temp").to_str().unwrap()),
         ))
     });
-    remove_file("./temp").expect("failed to remove temp bench file during activedata_etl bench");
 }
 
 #[bench]
 fn bench_output_covdir(b: &mut Bencher) {
+    let dir = tempdir().unwrap();
     b.iter(|| {
-        black_box(output_covdir(generate_cov_result_iter(), Some("./temp")));
+        black_box(output_covdir(
+            generate_cov_result_iter(),
+            Some(dir.path().join("temp").to_str().unwrap()),
+        ));
     });
-    remove_file("./temp").expect("failed to remove temp bench file during output_covdir");
 }
 
 #[bench]
 fn bench_output_lcov(b: &mut Bencher) {
+    let dir = tempdir().unwrap();
     b.iter(|| {
-        black_box(output_lcov(generate_cov_result_iter(), Some("./temp")));
+        black_box(output_lcov(
+            generate_cov_result_iter(),
+            Some(dir.path().join("temp").to_str().unwrap()),
+        ));
     });
-    remove_file("./temp").expect("failed to remove temp bench file during output_lcov bench");
 }

--- a/benches/output.rs
+++ b/benches/output.rs
@@ -1,0 +1,48 @@
+#![feature(test)]
+extern crate grcov;
+extern crate rustc_hash;
+extern crate test;
+
+use grcov::{output_activedata_etl, CovResult, Function, FunctionMap};
+use rustc_hash::FxHashMap;
+use std::path::PathBuf;
+use test::{black_box, Bencher};
+
+#[bench]
+fn bench_output_activedata_etl(b: &mut Bencher) {
+    b.iter(|| {
+        let j = Box::new(
+            FxHashMap::default()
+                .into_iter()
+                .map(|(_, _): (PathBuf, CovResult)| {
+                    (
+                        PathBuf::from(""),
+                        PathBuf::from(""),
+                        CovResult {
+                            branches: [].iter().cloned().collect(),
+                            functions: {
+                                let mut functions: FunctionMap = FxHashMap::default();
+                                functions.insert(
+                                    "f1".to_string(),
+                                    Function {
+                                        start: 1,
+                                        executed: true,
+                                    },
+                                );
+                                functions.insert(
+                                    "f2".to_string(),
+                                    Function {
+                                        start: 2,
+                                        executed: false,
+                                    },
+                                );
+                                functions
+                            },
+                            lines: [(1, 21), (2, 7), (7, 0)].iter().cloned().collect(),
+                        },
+                    )
+                }),
+        );
+        black_box(output_activedata_etl(j, None))
+    });
+}

--- a/benches/output.rs
+++ b/benches/output.rs
@@ -3,46 +3,72 @@ extern crate grcov;
 extern crate rustc_hash;
 extern crate test;
 
-use grcov::{output_activedata_etl, CovResult, Function, FunctionMap};
+use grcov::{
+    output_activedata_etl, output_covdir, output_lcov, CovResult, CovResultIter, Function,
+    FunctionMap,
+};
 use rustc_hash::FxHashMap;
+use std::fs::remove_file;
 use std::path::PathBuf;
 use test::{black_box, Bencher};
 
+fn generate_cov_result_iter() -> CovResultIter {
+    Box::new(
+        FxHashMap::default()
+            .into_iter()
+            .map(|(_, _): (PathBuf, CovResult)| {
+                (
+                    PathBuf::from(""),
+                    PathBuf::from(""),
+                    CovResult {
+                        branches: [].iter().cloned().collect(),
+                        functions: {
+                            let mut functions: FunctionMap = FxHashMap::default();
+                            functions.insert(
+                                "f1".to_string(),
+                                Function {
+                                    start: 1,
+                                    executed: true,
+                                },
+                            );
+                            functions.insert(
+                                "f2".to_string(),
+                                Function {
+                                    start: 2,
+                                    executed: false,
+                                },
+                            );
+                            functions
+                        },
+                        lines: [(1, 21), (2, 7), (7, 0)].iter().cloned().collect(),
+                    },
+                )
+            }),
+    )
+}
 #[bench]
 fn bench_output_activedata_etl(b: &mut Bencher) {
     b.iter(|| {
-        let j = Box::new(
-            FxHashMap::default()
-                .into_iter()
-                .map(|(_, _): (PathBuf, CovResult)| {
-                    (
-                        PathBuf::from(""),
-                        PathBuf::from(""),
-                        CovResult {
-                            branches: [].iter().cloned().collect(),
-                            functions: {
-                                let mut functions: FunctionMap = FxHashMap::default();
-                                functions.insert(
-                                    "f1".to_string(),
-                                    Function {
-                                        start: 1,
-                                        executed: true,
-                                    },
-                                );
-                                functions.insert(
-                                    "f2".to_string(),
-                                    Function {
-                                        start: 2,
-                                        executed: false,
-                                    },
-                                );
-                                functions
-                            },
-                            lines: [(1, 21), (2, 7), (7, 0)].iter().cloned().collect(),
-                        },
-                    )
-                }),
-        );
-        black_box(output_activedata_etl(j, None))
+        black_box(output_activedata_etl(
+            generate_cov_result_iter(),
+            Some("./temp"),
+        ))
     });
+    remove_file("./temp").expect("failed to remove temp bench file during activedata_etl bench");
+}
+
+#[bench]
+fn bench_output_covdir(b: &mut Bencher) {
+    b.iter(|| {
+        black_box(output_covdir(generate_cov_result_iter(), Some("./temp")));
+    });
+    remove_file("./temp").expect("failed to remove temp bench file during output_covdir");
+}
+
+#[bench]
+fn bench_output_lcov(b: &mut Bencher) {
+    b.iter(|| {
+        black_box(output_lcov(generate_cov_result_iter(), Some("./temp")));
+    });
+    remove_file("./temp").expect("failed to remove temp bench file during output_lcov bench");
 }


### PR DESCRIPTION
i added some benchmarks for the three output functions that i felt were benchmarkable. there weren't tests for coveralls, so i figured it was prolly safe to not bench it and the `output_files` function isn't doing a whole lot.

im not super sure if there is a better way to make the `CovResultIter` for the benches or if it should include more data or not. i tried messing around with cleaning it up, but couldn't ever get anything working because it gets moved into the closure and any variables declared outside of that box aren't guaranteed to live.

i'm also unsure if writing and removing the files like that is a good idea. it will overwrite and remove a file of the same name if it's there. `output_covdir` at least will write all of that data to the terminal if you pass it a `None`, tho, so we need to pass something in.

the function signature of the `thread::consumer` also changed and required an extra boolean arg in `benches/lib.rs` on line 118. all the other changes are white space from running rustfmt 

closes: https://github.com/mozilla/grcov/issues/82 