### PR TITLE
Allow user input to set branch name in coveralls report

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -147,7 +147,12 @@ fn main() {
 
                           .arg(Arg::with_name("guess_directory")
                                .long("guess-directory-when-missing"))
-
+                          
+                          .arg(Arg::with_name("vcs_branch")
+                               .help("Set the branch for coveralls report. Defaults to 'master'")
+                               .long("vcs-branch")
+                               .value_name("VCS BRANCH")
+                               .takes_value(true))
                           .get_matches();
 
     let paths: Vec<_> = matches.values_of("paths").unwrap().collect();
@@ -179,7 +184,7 @@ fn main() {
     let service_name = matches.value_of("service_name").unwrap_or("");
     let service_number = matches.value_of("service_number").unwrap_or("");
     let service_job_number = matches.value_of("service_job_number").unwrap_or("");
-    let branch = matches.value_of("branch").unwrap_or("master");
+    let branch = matches.value_of("vcs_branch").unwrap_or("master");
     let num_threads: usize = matches
         .value_of("threads")
         .unwrap()

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,6 +179,7 @@ fn main() {
     let service_name = matches.value_of("service_name").unwrap_or("");
     let service_number = matches.value_of("service_number").unwrap_or("");
     let service_job_number = matches.value_of("service_job_number").unwrap_or("");
+    let branch = matches.value_of("branch").unwrap_or("master");
     let num_threads: usize = matches
         .value_of("threads")
         .unwrap()

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,6 +151,7 @@ fn main() {
                           .arg(Arg::with_name("vcs_branch")
                                .help("Set the branch for coveralls report. Defaults to 'master'")
                                .long("vcs-branch")
+                               .default_value("master")
                                .value_name("VCS BRANCH")
                                .takes_value(true))
 
@@ -185,7 +186,7 @@ fn main() {
     let service_name = matches.value_of("service_name").unwrap_or("");
     let service_number = matches.value_of("service_number").unwrap_or("");
     let service_job_number = matches.value_of("service_job_number").unwrap_or("");
-    let vcs_branch = matches.value_of("vcs_branch").unwrap_or("master");
+    let vcs_branch = matches.value_of("vcs_branch").unwrap_or("");
     let num_threads: usize = matches
         .value_of("threads")
         .unwrap()

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,6 +179,7 @@ fn main() {
     let service_name = matches.value_of("service_name").unwrap_or("");
     let service_number = matches.value_of("service_number").unwrap_or("");
     let service_job_number = matches.value_of("service_job_number").unwrap_or("");
+    let branch = matches.value_of("branch").unwrap_or("master");
     let num_threads: usize = matches
         .value_of("threads")
         .unwrap()
@@ -202,7 +203,9 @@ fn main() {
     let tmp_path = tmp_dir.path().to_owned();
     assert!(tmp_path.exists());
 
-    let result_map: Arc<SyncCovResultMap> = Arc::new(Mutex::new(FxHashMap::with_capacity_and_hasher(20_000, Default::default())));
+    let result_map: Arc<SyncCovResultMap> = Arc::new(Mutex::new(
+        FxHashMap::with_capacity_and_hasher(20_000, Default::default()),
+    ));
     let (sender, receiver) = unbounded();
     let path_mapping: Arc<Mutex<Option<Value>>> = Arc::new(Mutex::new(None));
 
@@ -307,6 +310,7 @@ fn main() {
             commit_sha,
             false,
             output_file_path,
+            branch,
         );
     } else if output_type == "coveralls+" {
         output_coveralls(
@@ -318,6 +322,7 @@ fn main() {
             commit_sha,
             true,
             output_file_path,
+            branch,
         );
     } else if output_type == "files" {
         output_files(iterator, output_file_path);

--- a/src/main.rs
+++ b/src/main.rs
@@ -307,6 +307,7 @@ fn main() {
             commit_sha,
             false,
             output_file_path,
+            branch,
         );
     } else if output_type == "coveralls+" {
         output_coveralls(
@@ -318,6 +319,7 @@ fn main() {
             commit_sha,
             true,
             output_file_path,
+            branch,
         );
     } else if output_type == "files" {
         output_files(iterator, output_file_path);

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,7 +179,6 @@ fn main() {
     let service_name = matches.value_of("service_name").unwrap_or("");
     let service_number = matches.value_of("service_number").unwrap_or("");
     let service_job_number = matches.value_of("service_job_number").unwrap_or("");
-    let branch = matches.value_of("branch").unwrap_or("master");
     let num_threads: usize = matches
         .value_of("threads")
         .unwrap()
@@ -203,9 +202,7 @@ fn main() {
     let tmp_path = tmp_dir.path().to_owned();
     assert!(tmp_path.exists());
 
-    let result_map: Arc<SyncCovResultMap> = Arc::new(Mutex::new(
-        FxHashMap::with_capacity_and_hasher(20_000, Default::default()),
-    ));
+    let result_map: Arc<SyncCovResultMap> = Arc::new(Mutex::new(FxHashMap::with_capacity_and_hasher(20_000, Default::default())));
     let (sender, receiver) = unbounded();
     let path_mapping: Arc<Mutex<Option<Value>>> = Arc::new(Mutex::new(None));
 
@@ -310,7 +307,6 @@ fn main() {
             commit_sha,
             false,
             output_file_path,
-            branch,
         );
     } else if output_type == "coveralls+" {
         output_coveralls(
@@ -322,7 +318,6 @@ fn main() {
             commit_sha,
             true,
             output_file_path,
-            branch,
         );
     } else if output_type == "files" {
         output_files(iterator, output_file_path);

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,6 +153,7 @@ fn main() {
                                .long("vcs-branch")
                                .value_name("VCS BRANCH")
                                .takes_value(true))
+
                           .get_matches();
 
     let paths: Vec<_> = matches.values_of("paths").unwrap().collect();
@@ -184,7 +185,7 @@ fn main() {
     let service_name = matches.value_of("service_name").unwrap_or("");
     let service_number = matches.value_of("service_number").unwrap_or("");
     let service_job_number = matches.value_of("service_job_number").unwrap_or("");
-    let branch = matches.value_of("vcs_branch").unwrap_or("master");
+    let vcs_branch = matches.value_of("vcs_branch").unwrap_or("master");
     let num_threads: usize = matches
         .value_of("threads")
         .unwrap()
@@ -313,7 +314,7 @@ fn main() {
             commit_sha,
             false,
             output_file_path,
-            branch,
+            vcs_branch,
         );
     } else if output_type == "coveralls+" {
         output_coveralls(
@@ -325,7 +326,7 @@ fn main() {
             commit_sha,
             true,
             output_file_path,
-            branch,
+            vcs_branch,
         );
     } else if output_type == "files" {
         output_files(iterator, output_file_path);

--- a/src/output.rs
+++ b/src/output.rs
@@ -273,7 +273,7 @@ pub fn output_coveralls(
     commit_sha: &str,
     with_function_info: bool,
     output_file: Option<&str>,
-    branch: &str,
+    vcs_branch: &str,
 ) {
     let mut source_files = Vec::new();
 
@@ -336,7 +336,7 @@ pub fn output_coveralls(
               "head": {
                 "id": commit_sha,
               },
-              "branch": branch,
+              "branch": vcs_branch,
             },
             "source_files": source_files,
             "service_name": service_name,

--- a/src/output.rs
+++ b/src/output.rs
@@ -273,6 +273,7 @@ pub fn output_coveralls(
     commit_sha: &str,
     with_function_info: bool,
     output_file: Option<&str>,
+    branch: &str,
 ) {
     let mut source_files = Vec::new();
 
@@ -335,7 +336,7 @@ pub fn output_coveralls(
               "head": {
                 "id": commit_sha,
               },
-              "branch": "master",
+              "branch": branch,
             },
             "source_files": source_files,
             "service_name": service_name,

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,4 +1,3 @@
-use md5::{Digest, Md5};
 use rustc_hash::FxHashMap;
 use serde_json::{self, Value};
 use std::cell::RefCell;
@@ -8,6 +7,7 @@ use std::io::{self, BufWriter, Read, Write};
 use std::path::PathBuf;
 use std::rc::Rc;
 use uuid::Uuid;
+use md5::{Md5, Digest};
 
 use crate::defs::*;
 
@@ -166,26 +166,24 @@ pub fn output_covdir(results: CovResultIter, output_file: Option<&str>) {
                     } else {
                         ancestor.file_name().unwrap().to_str().unwrap().to_string()
                     };
-                    prev_stats
-                        .dirs
-                        .push(Rc::new(RefCell::new(CDDirStats::new(path_tail))));
+                    prev_stats.dirs.push(Rc::new(RefCell::new(CDDirStats::new(path_tail))));
                     let last = prev_stats.dirs.last_mut().unwrap();
                     p.insert(last.clone());
                     last.clone()
-                }
+                },
             };
         }
 
-        prev_stats.borrow_mut().files.push(CDFileStats::new(
-            path.file_name().unwrap().to_str().unwrap().to_string(),
-            result.lines,
-        ));
+        prev_stats.borrow_mut().files.push(CDFileStats::new(path.file_name().unwrap().to_str().unwrap().to_string(), result.lines));
     }
 
     let mut global = global.borrow_mut();
     global.set_stats();
 
-    serde_json::to_writer(&mut writer, &global.to_json()).unwrap();
+    serde_json::to_writer(
+        &mut writer,
+        &global.to_json(),
+    ).unwrap();
 }
 
 pub fn output_lcov(results: CovResultIter, output_file: Option<&str>) {
@@ -275,7 +273,6 @@ pub fn output_coveralls(
     commit_sha: &str,
     with_function_info: bool,
     output_file: Option<&str>,
-    branch: &str,
 ) {
     let mut source_files = Vec::new();
 
@@ -338,7 +335,7 @@ pub fn output_coveralls(
               "head": {
                 "id": commit_sha,
               },
-              "branch": branch,
+              "branch": "master",
             },
             "source_files": source_files,
             "service_name": service_name,
@@ -364,8 +361,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     fn read_file(path: &PathBuf) -> String {
-        let mut f =
-            File::open(path).expect(format!("{:?} file not found", path.file_name()).as_str());
+        let mut f = File::open(path).expect(format!("{:?} file not found", path.file_name()).as_str());
         let mut s = String::new();
         f.read_to_string(&mut s).unwrap();
         s
@@ -378,42 +374,34 @@ mod tests {
         let file_path = tmp_dir.path().join(&file_name);
 
         let results = vec![
-            (
-                PathBuf::from("foo/bar/a.cpp"),
-                PathBuf::from("foo/bar/a.cpp"),
-                CovResult {
-                    lines: [(1, 10), (2, 11)].iter().cloned().collect(),
-                    branches: BTreeMap::new(),
-                    functions: FxHashMap::default(),
-                },
-            ),
-            (
-                PathBuf::from("foo/bar/b.cpp"),
-                PathBuf::from("foo/bar/b.cpp"),
-                CovResult {
-                    lines: [(1, 0), (2, 10), (4, 0)].iter().cloned().collect(),
-                    branches: BTreeMap::new(),
-                    functions: FxHashMap::default(),
-                },
-            ),
-            (
-                PathBuf::from("foo/c.cpp"),
-                PathBuf::from("foo/c.cpp"),
-                CovResult {
-                    lines: [(1, 10), (4, 1)].iter().cloned().collect(),
-                    branches: BTreeMap::new(),
-                    functions: FxHashMap::default(),
-                },
-            ),
-            (
-                PathBuf::from("/foo/d.cpp"),
-                PathBuf::from("/foo/d.cpp"),
-                CovResult {
-                    lines: [(1, 10), (2, 0)].iter().cloned().collect(),
-                    branches: BTreeMap::new(),
-                    functions: FxHashMap::default(),
-                },
-            ),
+            (PathBuf::from("foo/bar/a.cpp"),
+             PathBuf::from("foo/bar/a.cpp"),
+             CovResult {
+                 lines: [(1, 10), (2, 11)].iter().cloned().collect(),
+                 branches: BTreeMap::new(),
+                 functions: FxHashMap::default(),
+             }),
+            (PathBuf::from("foo/bar/b.cpp"),
+             PathBuf::from("foo/bar/b.cpp"),
+             CovResult {
+                 lines: [(1, 0), (2, 10), (4, 0)].iter().cloned().collect(),
+                 branches: BTreeMap::new(),
+                 functions: FxHashMap::default(),
+             }),
+            (PathBuf::from("foo/c.cpp"),
+             PathBuf::from("foo/c.cpp"),
+             CovResult {
+                 lines: [(1, 10), (4, 1)].iter().cloned().collect(),
+                 branches: BTreeMap::new(),
+                 functions: FxHashMap::default(),
+             }),
+            (PathBuf::from("/foo/d.cpp"),
+             PathBuf::from("/foo/d.cpp"),
+             CovResult {
+                 lines: [(1, 10), (2, 0)].iter().cloned().collect(),
+                 branches: BTreeMap::new(),
+                 functions: FxHashMap::default(),
+             }),
         ];
 
         let results = Box::new(results.into_iter());

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,3 +1,4 @@
+use md5::{Digest, Md5};
 use rustc_hash::FxHashMap;
 use serde_json::{self, Value};
 use std::cell::RefCell;
@@ -7,7 +8,6 @@ use std::io::{self, BufWriter, Read, Write};
 use std::path::PathBuf;
 use std::rc::Rc;
 use uuid::Uuid;
-use md5::{Md5, Digest};
 
 use crate::defs::*;
 
@@ -166,24 +166,26 @@ pub fn output_covdir(results: CovResultIter, output_file: Option<&str>) {
                     } else {
                         ancestor.file_name().unwrap().to_str().unwrap().to_string()
                     };
-                    prev_stats.dirs.push(Rc::new(RefCell::new(CDDirStats::new(path_tail))));
+                    prev_stats
+                        .dirs
+                        .push(Rc::new(RefCell::new(CDDirStats::new(path_tail))));
                     let last = prev_stats.dirs.last_mut().unwrap();
                     p.insert(last.clone());
                     last.clone()
-                },
+                }
             };
         }
 
-        prev_stats.borrow_mut().files.push(CDFileStats::new(path.file_name().unwrap().to_str().unwrap().to_string(), result.lines));
+        prev_stats.borrow_mut().files.push(CDFileStats::new(
+            path.file_name().unwrap().to_str().unwrap().to_string(),
+            result.lines,
+        ));
     }
 
     let mut global = global.borrow_mut();
     global.set_stats();
 
-    serde_json::to_writer(
-        &mut writer,
-        &global.to_json(),
-    ).unwrap();
+    serde_json::to_writer(&mut writer, &global.to_json()).unwrap();
 }
 
 pub fn output_lcov(results: CovResultIter, output_file: Option<&str>) {
@@ -273,6 +275,7 @@ pub fn output_coveralls(
     commit_sha: &str,
     with_function_info: bool,
     output_file: Option<&str>,
+    branch: &str,
 ) {
     let mut source_files = Vec::new();
 
@@ -335,7 +338,7 @@ pub fn output_coveralls(
               "head": {
                 "id": commit_sha,
               },
-              "branch": "master",
+              "branch": branch,
             },
             "source_files": source_files,
             "service_name": service_name,
@@ -361,7 +364,8 @@ mod tests {
     use std::collections::BTreeMap;
 
     fn read_file(path: &PathBuf) -> String {
-        let mut f = File::open(path).expect(format!("{:?} file not found", path.file_name()).as_str());
+        let mut f =
+            File::open(path).expect(format!("{:?} file not found", path.file_name()).as_str());
         let mut s = String::new();
         f.read_to_string(&mut s).unwrap();
         s
@@ -374,34 +378,42 @@ mod tests {
         let file_path = tmp_dir.path().join(&file_name);
 
         let results = vec![
-            (PathBuf::from("foo/bar/a.cpp"),
-             PathBuf::from("foo/bar/a.cpp"),
-             CovResult {
-                 lines: [(1, 10), (2, 11)].iter().cloned().collect(),
-                 branches: BTreeMap::new(),
-                 functions: FxHashMap::default(),
-             }),
-            (PathBuf::from("foo/bar/b.cpp"),
-             PathBuf::from("foo/bar/b.cpp"),
-             CovResult {
-                 lines: [(1, 0), (2, 10), (4, 0)].iter().cloned().collect(),
-                 branches: BTreeMap::new(),
-                 functions: FxHashMap::default(),
-             }),
-            (PathBuf::from("foo/c.cpp"),
-             PathBuf::from("foo/c.cpp"),
-             CovResult {
-                 lines: [(1, 10), (4, 1)].iter().cloned().collect(),
-                 branches: BTreeMap::new(),
-                 functions: FxHashMap::default(),
-             }),
-            (PathBuf::from("/foo/d.cpp"),
-             PathBuf::from("/foo/d.cpp"),
-             CovResult {
-                 lines: [(1, 10), (2, 0)].iter().cloned().collect(),
-                 branches: BTreeMap::new(),
-                 functions: FxHashMap::default(),
-             }),
+            (
+                PathBuf::from("foo/bar/a.cpp"),
+                PathBuf::from("foo/bar/a.cpp"),
+                CovResult {
+                    lines: [(1, 10), (2, 11)].iter().cloned().collect(),
+                    branches: BTreeMap::new(),
+                    functions: FxHashMap::default(),
+                },
+            ),
+            (
+                PathBuf::from("foo/bar/b.cpp"),
+                PathBuf::from("foo/bar/b.cpp"),
+                CovResult {
+                    lines: [(1, 0), (2, 10), (4, 0)].iter().cloned().collect(),
+                    branches: BTreeMap::new(),
+                    functions: FxHashMap::default(),
+                },
+            ),
+            (
+                PathBuf::from("foo/c.cpp"),
+                PathBuf::from("foo/c.cpp"),
+                CovResult {
+                    lines: [(1, 10), (4, 1)].iter().cloned().collect(),
+                    branches: BTreeMap::new(),
+                    functions: FxHashMap::default(),
+                },
+            ),
+            (
+                PathBuf::from("/foo/d.cpp"),
+                PathBuf::from("/foo/d.cpp"),
+                CovResult {
+                    lines: [(1, 10), (2, 0)].iter().cloned().collect(),
+                    branches: BTreeMap::new(),
+                    functions: FxHashMap::default(),
+                },
+            ),
         ];
 
         let results = Box::new(results.into_iter());


### PR DESCRIPTION
This PR is intended to implement the request in issue #300. It should maintain all existing functionality by default to set the "master" branch unless additional input is provided by the user.

I ran `cargo fmt`, which is why there are a few stylistic changes. Sorry, I didn't realize the rest of the codebase wasn't run with `cargo fmt`. If that's really distracting I can revert and just add the functional changes with no stylistic changes.

Otherwise, I would greatly appreciate any feedback if this makes sense or if there's anything else needed to merge. Thanks!