### PR TITLE
Add Pre-Commit hook and README instructions (try #2)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.2.3
+    hooks:
+    -   id: check-yaml
+-   repo: local
+    hooks:
+      - id: fmt
+        name: fmt
+        language: system
+        files: '\.rs$'
+        entry: cargo fmt -- --check # rustup run nightly rustfmt
+
+      # - id: clippy
+      #   name: clippy
+      #   language: system
+      #   files: '\.rs$'
+      #   entry: cargo clippy --all-targets --all -- -Dwarnings 
+      #   pass_filenames: false
+
+      - id: test
+        name: test
+        language: system
+        files: '\.rs$'
+        entry: cargo test
+        pass_filenames: false
+
+default_language_version:
+    python: python3.7

--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ script:
       bash <(curl -s https://codecov.io/bash) -f lcov.info;
 ```
 
+### Auto-formatting
+
+This project is using pre-commit. Please run `pre-commit install` to install the git pre-commit hooks on your clone. Instructions on how to install pre-commit can be found [here](https://pre-commit.com/#install).
+
+Every time you will try to commit, pre-commit will run checks on your files to make sure they follow our style standards and they aren't affected by some simple issues. If the checks fail, pre-commit won't let you commit.
+
 ## Build & Test
 
 In order to build, either LLVM 7 or LLVM 8 libraries and headers are required. If one of these versions is sucessfully installed, build with:

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -81,19 +81,20 @@ fn bench_lib_merge_results(b: &mut Bencher) {
 #[bench]
 fn bench_lib_consumer(b: &mut Bencher) {
     let num_threads = 2;
-    let result_map: Arc<SyncCovResultMap> = Arc::new(Mutex::new(FxHashMap::with_capacity_and_hasher(20_000, Default::default())));
+    let result_map: Arc<SyncCovResultMap> = Arc::new(Mutex::new(
+        FxHashMap::with_capacity_and_hasher(20_000, Default::default()),
+    ));
     let (sender, receiver) = unbounded();
     let source_root = None;
     let working_dir = PathBuf::from("");
     let gcno_buf: Vec<u8> = vec![
-        111, 110, 99, 103, 42, 50, 48, 52, 74, 200, 254, 66, 0, 0, 0, 1, 9, 0, 0, 0, 0, 0, 0,
-        0, 236, 217, 93, 255, 2, 0, 0, 0, 109, 97, 105, 110, 0, 0, 0, 0, 2, 0, 0, 0, 102, 105,
-        108, 101, 46, 99, 0, 0, 1, 0, 0, 0, 0, 0, 65, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 67, 1, 3, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 67, 1, 3,
-        0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 69, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 69, 1, 8, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 102,
-        105, 108, 101, 46, 99, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0,
+        111, 110, 99, 103, 42, 50, 48, 52, 74, 200, 254, 66, 0, 0, 0, 1, 9, 0, 0, 0, 0, 0, 0, 0,
+        236, 217, 93, 255, 2, 0, 0, 0, 109, 97, 105, 110, 0, 0, 0, 0, 2, 0, 0, 0, 102, 105, 108,
+        101, 46, 99, 0, 0, 1, 0, 0, 0, 0, 0, 65, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 67, 1, 3, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 67, 1, 3, 0, 0, 0, 1, 0,
+        0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 69, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 69, 1, 8, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 102, 105, 108, 101, 46, 99, 0,
+        0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ];
 
     b.iter(|| {
@@ -108,13 +109,7 @@ fn bench_lib_consumer(b: &mut Bencher) {
             let t = thread::Builder::new()
                 .name(format!("Consumer {}", i))
                 .spawn(move || {
-                    consumer(
-                        &working_dir,
-                        &source_root,
-                        &result_map,
-                        receiver,
-                        false,
-                    );
+                    consumer(&working_dir, &source_root, &result_map, receiver, false);
                 })
                 .unwrap();
 
@@ -122,18 +117,17 @@ fn bench_lib_consumer(b: &mut Bencher) {
         }
 
         for _ in 0..10_000 {
-            sender.send(Some(
-                WorkItem {
+            sender
+                .send(Some(WorkItem {
                     format: ItemFormat::GCNO,
-                    item: ItemType::Buffers(
-                        GcnoBuffers {
-                            stem: "".to_string(),
-                            gcno_buf: gcno_buf.clone(),
-                            gcda_buf: Vec::new(),
-                        }),
+                    item: ItemType::Buffers(GcnoBuffers {
+                        stem: "".to_string(),
+                        gcno_buf: gcno_buf.clone(),
+                        gcda_buf: Vec::new(),
+                    }),
                     name: "".to_string(),
-                })
-            ).unwrap();
+                }))
+                .unwrap();
         }
 
         for _ in 0..num_threads {

--- a/src/covdir.rs
+++ b/src/covdir.rs
@@ -4,7 +4,6 @@ use std::collections::BTreeMap;
 pub use crate::defs::*;
 
 impl CDStats {
-
     pub fn new(total: usize, covered: usize) -> Self {
         let missed = total - covered;
         Self {
@@ -38,7 +37,6 @@ impl CDStats {
 }
 
 impl CDFileStats {
-
     pub fn new(name: String, coverage: BTreeMap<u32, u64>) -> Self {
         let (total, covered, lines) = Self::get_coverage(coverage);
         Self {
@@ -76,7 +74,6 @@ impl CDFileStats {
 }
 
 impl CDDirStats {
-
     pub fn new(name: String) -> Self {
         Self {
             name,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ extern crate crossbeam;
 #[macro_use]
 extern crate fomat_macros;
 extern crate globset;
+extern crate rustc_hash;
 extern crate semver;
 extern crate smallvec;
 extern crate tempfile;
@@ -13,7 +14,6 @@ extern crate uuid;
 extern crate walkdir;
 extern crate xml;
 extern crate zip;
-extern crate rustc_hash;
 
 mod defs;
 pub use crate::defs::*;
@@ -49,7 +49,6 @@ use std::fs;
 use std::io::{BufReader, Cursor};
 use std::path::PathBuf;
 use walkdir::WalkDir;
-
 
 // Merge results, without caring about duplicate lines (they will be removed at the end).
 pub fn merge_results(result: &mut CovResult, result2: CovResult) {
@@ -228,7 +227,7 @@ pub fn consumer(
                                     rename_single_files(&mut r, &buffers.stem);
                                 }
                                 r
-                            },
+                            }
                             Err(e) => {
                                 // Just print the error, don't panic and continue
                                 eprintln!("Error in computing counters:\n{}", e);
@@ -362,7 +361,9 @@ mod tests {
             .expect("Failed to open lcov file");
         let file = BufReader::new(&f);
         let results = parse_lcov(file, false).unwrap();
-        let result_map: Arc<SyncCovResultMap> = Arc::new(Mutex::new(FxHashMap::with_capacity_and_hasher(1, Default::default())));
+        let result_map: Arc<SyncCovResultMap> = Arc::new(Mutex::new(
+            FxHashMap::with_capacity_and_hasher(1, Default::default()),
+        ));
         add_results(
             results,
             &result_map,
@@ -393,7 +394,9 @@ mod tests {
             .expect("Failed to open lcov file");
         let file = BufReader::new(&f);
         let results = parse_lcov(file, false).unwrap();
-        let result_map: Arc<SyncCovResultMap> = Arc::new(Mutex::new(FxHashMap::with_capacity_and_hasher(3, Default::default())));
+        let result_map: Arc<SyncCovResultMap> = Arc::new(Mutex::new(
+            FxHashMap::with_capacity_and_hasher(3, Default::default()),
+        ));
         add_results(results, &result_map, &None);
         let result_map = Arc::try_unwrap(result_map).unwrap().into_inner().unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,7 +147,7 @@ fn main() {
 
                           .arg(Arg::with_name("guess_directory")
                                .long("guess-directory-when-missing"))
-                          
+
                           .arg(Arg::with_name("vcs_branch")
                                .help("Set the branch for coveralls report. Defaults to 'master'")
                                .long("vcs-branch")
@@ -210,7 +210,9 @@ fn main() {
     let tmp_path = tmp_dir.path().to_owned();
     assert!(tmp_path.exists());
 
-    let result_map: Arc<SyncCovResultMap> = Arc::new(Mutex::new(FxHashMap::with_capacity_and_hasher(20_000, Default::default())));
+    let result_map: Arc<SyncCovResultMap> = Arc::new(Mutex::new(
+        FxHashMap::with_capacity_and_hasher(20_000, Default::default()),
+    ));
     let (sender, receiver) = unbounded();
     let path_mapping: Arc<Mutex<Option<Value>>> = Arc::new(Mutex::new(None));
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -56,7 +56,7 @@ macro_rules! try_next {
         if let Some(val) = $v.next() {
             val
         } else {
-            return Err(ParserError::InvalidRecord($l.to_string()))
+            return Err(ParserError::InvalidRecord($l.to_string()));
         }
     };
 }

--- a/src/path_rewriting.rs
+++ b/src/path_rewriting.rs
@@ -63,7 +63,10 @@ pub fn normalize_path<P: AsRef<Path>>(path: P) -> Option<PathBuf> {
             Component::CurDir => {}
             Component::ParentDir => {
                 if !ret.pop() {
-                    eprintln!("Warning: {:?} cannot be normalized because of \"..\", so skip it.", path.as_ref());
+                    eprintln!(
+                        "Warning: {:?} cannot be normalized because of \"..\", so skip it.",
+                        path.as_ref()
+                    );
                     return None;
                 }
             }
@@ -1239,10 +1242,22 @@ mod tests {
 
     #[test]
     fn test_normalize_path() {
-        assert_eq!(normalize_path("./foo/bar").unwrap(), PathBuf::from("foo/bar"));
-        assert_eq!(normalize_path("./foo//bar").unwrap(), PathBuf::from("foo/bar"));
-        assert_eq!(normalize_path("./foo/./bar/./oof/").unwrap(), PathBuf::from("foo/bar/oof"));
-        assert_eq!(normalize_path("./foo/../bar/./oof/").unwrap(), PathBuf::from("bar/oof"));
+        assert_eq!(
+            normalize_path("./foo/bar").unwrap(),
+            PathBuf::from("foo/bar")
+        );
+        assert_eq!(
+            normalize_path("./foo//bar").unwrap(),
+            PathBuf::from("foo/bar")
+        );
+        assert_eq!(
+            normalize_path("./foo/./bar/./oof/").unwrap(),
+            PathBuf::from("foo/bar/oof")
+        );
+        assert_eq!(
+            normalize_path("./foo/../bar/./oof/").unwrap(),
+            PathBuf::from("bar/oof")
+        );
         assert!(normalize_path("../bar/oof/").is_none());
         assert!(normalize_path("bar/foo/../../../oof/").is_none());
     }

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -296,11 +296,13 @@ fn gcno_gcda_producer(
     ignore_orphan_gcno: bool,
 ) {
     let send_job = |item, name| {
-        sender.send(Some(WorkItem {
-            format: ItemFormat::GCNO,
-            item: item,
-            name: name,
-        })).unwrap()
+        sender
+            .send(Some(WorkItem {
+                format: ItemFormat::GCNO,
+                item: item,
+                name: name,
+            }))
+            .unwrap()
     };
 
     for (gcno_stem, gcno_archive) in gcno_stem_archives {
@@ -342,8 +344,7 @@ fn gcno_gcda_producer(
                     }
 
                     let gcda_path = tmp_dir.join(format!("{}_{}.gcda", stem, num + 1));
-                    if gcda_archive.extract(&gcda, &gcda_path)
-                        || (num == 0 && !ignore_orphan_gcno)
+                    if gcda_archive.extract(&gcda, &gcda_path) || (num == 0 && !ignore_orphan_gcno)
                     {
                         send_job(
                             ItemType::Path((stem.clone(), gcno_path)),
@@ -391,11 +392,13 @@ fn file_content_producer(
         for archive in archives {
             let mut buffer = Vec::new();
             archive.read_in_buffer(name, &mut buffer);
-            sender.send(Some(WorkItem {
-                format: item_format,
-                item: ItemType::Content(buffer),
-                name: archive.get_name().to_string(),
-            })).unwrap();
+            sender
+                .send(Some(WorkItem {
+                    format: item_format,
+                    item: ItemType::Content(buffer),
+                    name: archive.get_name().to_string(),
+                }))
+                .unwrap();
         }
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -956,8 +956,8 @@ impl GcovFunction {
 #[cfg(test)]
 mod tests {
 
-use crate::defs::FunctionMap;
-use super::*;
+    use super::*;
+    use crate::defs::FunctionMap;
 
     fn get_input_string(path: &str) -> String {
         let path = PathBuf::from(path);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -365,7 +365,13 @@ fn check_equal_covdir(expected_output: &str, output: &str) {
 
     println!("{}", serde_json::to_string_pretty(&actual).unwrap());
 
-    for field in vec!["coveragePercent", "linesCovered", "linesMissed", "linesTotal", "name"] {
+    for field in vec![
+        "coveragePercent",
+        "linesCovered",
+        "linesMissed",
+        "linesTotal",
+        "name",
+    ] {
         assert_eq!(expected[field], actual[field])
     }
 }
@@ -574,15 +580,9 @@ fn test_integration_zip_zip() {
             &run_grcov(vec![&gcno_zip_path, &gcda0_zip_path], path, "coveralls"),
             false,
         );
-                
+
         check_equal_covdir(
-            &read_expected(
-                path,
-                &name,
-                &compiler_version,
-                "covdir",
-                Some("_no_gcda"),
-            ),
+            &read_expected(path, &name, &compiler_version, "covdir", Some("_no_gcda")),
             &run_grcov(vec![&gcno_zip_path, &gcda0_zip_path], path, "covdir"),
         );
 
@@ -621,13 +621,7 @@ fn test_integration_zip_zip() {
         );
 
         check_equal_covdir(
-            &read_expected(
-                path,
-                &name,
-                &compiler_version,
-                "covdir",
-                Some("_two_gcda"),
-            ),
+            &read_expected(path, &name, &compiler_version, "covdir", Some("_two_gcda")),
             &run_grcov(
                 vec![&gcno_zip_path, &gcda_zip_path, &gcda1_zip_path],
                 path,


### PR DESCRIPTION
This PR is to address issue #302. Included in the commits are:

1. Formatting of all existing rust files with cargo fmt.
2.  A .pre-commit-config.yaml file for future formatting and testing as a pre-commit hook.
3. Additions to the README to include the pre-commit installation instructions. I modified what was written in the [Bugbug](https://github.com/mozilla/bugbug#auto-formatting) project to include a link to install pre-commit.

I originally attempted this with PR #303 but I accidentally added some conflicts, and it was a bit confusing as the history included some work related to a separate PR. This should be a cleaner version.

Note, I have included but commented out the hook to run cargo clippy. Running clippy seems to include a large number of warnings and errors that are substantial enough I think it makes more sense to address them in a separate issue/PR.

Sorry for the hassle with a 2nd PR and thanks for your feedback!