### PR TITLE
Use `CWD` as default source_dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,7 @@ script:
     - |
       if [ "$TRAVIS_RUST_VERSION" = "nightly" ] && [ -z "$TRAVIS_TAG" ]; then
         zip -0 ccov.zip `find . \( -name "grcov*.gc*" -o -name "llvmgcov.gc*" \) -print`;
-        ./target/debug/grcov ccov.zip -s . -t lcov --llvm --branch --ignore-not-existing --ignore-dir "/*" -o lcov.info;
+        ./target/debug/grcov ccov.zip -t lcov --llvm --branch --ignore-not-existing --ignore-dir "/*" -o lcov.info;
         bash <(curl -s https://codecov.io/bash) -f lcov.info;
       fi
 before_deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,7 +56,7 @@ test_script:
       If ($env:CHANNEL -eq "nightly" -And $env:APPVEYOR_REPO_TAG -eq "false") {
          mkdir ccov_dir
          Get-ChildItem -Path *\grcov*.gc* -Recurse | Copy-Item -Destination ccov_dir
-         .\target\debug\grcov ccov_dir -s . -t lcov --llvm --branch --ignore-not-existing --ignore-dir "C:*" -o lcov.info
+         .\target\debug\grcov ccov_dir -t lcov --llvm --branch --ignore-not-existing --ignore-dir "C:*" -o lcov.info
          (Get-Content lcov.info) | Foreach-Object {$_ -replace "\xEF\xBB\xBF", ""} | Set-Content lcov.info
          ((Get-Content lcov.info) -join "`n") + "`n" | Set-Content -NoNewline lcov.info
          $env:PATH = "C:\msys64\usr\bin;" + $env:PATH

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,7 +175,10 @@ fn main() {
     let paths: Vec<String> = paths.iter().map(|s| s.to_string()).collect();
     let output_type = matches.value_of("output_type").unwrap();
     let output_file_path = matches.value_of("output_file");
-    let source_dir = matches.value_of("source_dir").unwrap_or("");
+    let current_dir = std::env::current_dir().unwrap();
+    let source_dir = matches
+        .value_of("source_dir")
+        .unwrap_or(current_dir.to_str().unwrap());
     let prefix_dir = matches.value_of("prefix_dir").unwrap_or("");
     let ignore_not_existing = matches.is_present("ignore_not_existing");
     let mut to_ignore_dirs: Vec<_> = if let Some(to_ignore_dirs) = matches.values_of("ignore_dir") {


### PR DESCRIPTION
Changes made:
 - use `env::current_dir` as the default `source_dir`
 - remove `-s .` patterns from  `.travis.yml` and `appveyor.yml` 

This PR closes #205.  
The issue does seem to be stale, so I took this up. I apologize if this causes any inconvenience.