### PR TITLE
rename `ignore-dir` flag to `ignore`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,7 @@ script:
     - |
       if [ "$TRAVIS_RUST_VERSION" = "nightly" ] && [ -z "$TRAVIS_TAG" ]; then
         zip -0 ccov.zip `find . \( -name "grcov*.gc*" -o -name "llvmgcov.gc*" \) -print`;
-        ./target/debug/grcov ccov.zip -s . -t lcov --llvm --branch --ignore-not-existing --ignore-dir "/*" -o lcov.info;
+        ./target/debug/grcov ccov.zip -s . -t lcov --llvm --branch --ignore-not-existing --ignore "/*" -o lcov.info;
         bash <(curl -s https://codecov.io/bash) -f lcov.info;
       fi
 before_deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,7 +56,7 @@ test_script:
       If ($env:CHANNEL -eq "nightly" -And $env:APPVEYOR_REPO_TAG -eq "false") {
          mkdir ccov_dir
          Get-ChildItem -Path *\grcov*.gc* -Recurse | Copy-Item -Destination ccov_dir
-         .\target\debug\grcov ccov_dir -s . -t lcov --llvm --branch --ignore-not-existing --ignore-dir "C:*" -o lcov.info
+         .\target\debug\grcov ccov_dir -s . -t lcov --llvm --branch --ignore-not-existing --ignore "C:*" -o lcov.info
          (Get-Content lcov.info) | Foreach-Object {$_ -replace "\xEF\xBB\xBF", ""} | Set-Content lcov.info
          ((Get-Content lcov.info) -join "`n") + "`n" | Set-Content -NoNewline lcov.info
          $env:PATH = "C:\msys64\usr\bin;" + $env:PATH

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ fn main() {
 
                           .arg(Arg::with_name("ignore_dir")
                                .help("Ignore files/directories specified as globs")
-                               .long("ignore-dir")
+                               .long("ignore")
                                .value_name("PATH")
                                .multiple(true)
                                .number_of_values(1)

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -139,11 +139,11 @@ fn run_grcov(paths: Vec<&Path>, source_root: &Path, output_format: &str) -> Stri
         args.push(source_root.to_str().unwrap());
         args.push("--branch");
     }
-    args.push("--ignore-dir");
+    args.push("--ignore");
     args.push("C:/*");
-    args.push("--ignore-dir");
+    args.push("--ignore");
     args.push("/usr/*");
-    args.push("--ignore-dir");
+    args.push("--ignore");
     args.push("/Applications/*");
     args.push("--guess-directory-when-missing");
 


### PR DESCRIPTION
Fixes #193 

@marco-c @calixteman let me know what you think. maybe we could add a short `-I` flag as well.