### PR TITLE
README.md: fix old argument name

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ script:
     - cargo test --verbose $CARGO_OPTIONS
     - |
       zip -0 ccov.zip `find . \( -name "YOUR_PROJECT_NAME*.gc*" \) -print`;
-      ./grcov ccov.zip -s . -t lcov --llvm --branch --ignore-not-existing --ignore-dir "/*" -o lcov.info;
+      ./grcov ccov.zip -s . -t lcov --llvm --branch --ignore-not-existing --ignore "/*" -o lcov.info;
       bash <(curl -s https://codecov.io/bash) -f lcov.info;
 ```
 


### PR DESCRIPTION
The paramter ignore-dir was renamed to ignore a week ago. The
documentation should reflect these changes.