### PR TITLE
Add --service-pull-request

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ OPTIONS:
         --service-job-number <SERVICE JOB NUMBER>    Sets the service job number
         --service-name <SERVICE NAME>                Sets the service name
         --service-number <SERVICE NUMBER>            Sets the service number
+        --service-pull-request <SERVICE PULL REQUEST>
+                                                     Sets the service pull request number
+
     -s, --source-dir <DIRECTORY>                     Specifies the root directory of the source files
         --threads <NUMBER>                            [default: 16]
         --token <TOKEN>

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,6 +145,12 @@ fn main() {
                                .value_name("SERVICE JOB NUMBER")
                                .takes_value(true))
 
+                          .arg(Arg::with_name("service_pull_request")
+                               .help("Sets the service pull request number")
+                               .long("service-pull-request")
+                               .value_name("SERVICE PULL REQUEST")
+                               .takes_value(true))
+
                           .arg(Arg::with_name("parallel")
                                .help("Sets the build type to be parallel for 'coveralls' and 'coveralls+' formats")
                                .long("parallel"))
@@ -204,6 +210,7 @@ fn main() {
     let is_parallel = matches.is_present("parallel");
     let service_number = matches.value_of("service_number").unwrap_or("");
     let service_job_number = matches.value_of("service_job_number").unwrap_or("");
+    let service_pull_request = matches.value_of("service_pull_request").unwrap_or("");
     let vcs_branch = matches.value_of("vcs_branch").unwrap_or("");
     let log = matches.value_of("log").unwrap_or("");
     match log {
@@ -370,6 +377,7 @@ fn main() {
             service_name,
             service_number,
             service_job_number,
+            service_pull_request,
             commit_sha,
             false,
             output_file_path,
@@ -383,6 +391,7 @@ fn main() {
             service_name,
             service_number,
             service_job_number,
+            service_pull_request,
             commit_sha,
             true,
             output_file_path,

--- a/src/output.rs
+++ b/src/output.rs
@@ -276,6 +276,7 @@ pub fn output_coveralls(
     service_name: &str,
     service_number: &str,
     service_job_number: &str,
+    service_pull_request: &str,
     commit_sha: &str,
     with_function_info: bool,
     output_file: Option<&str>,
@@ -349,6 +350,7 @@ pub fn output_coveralls(
             "service_name": service_name,
             "service_number": service_number,
             "service_job_number": service_job_number,
+            "service_pull_request": service_pull_request,
             "parallel": parallel,
         }),
     )


### PR DESCRIPTION
This option adds `service_pull_request` key to JSON, which, according to [Coveralls docs](https://docs.coveralls.io/api-reference), is "[u]sed for updating the status and/or commenting". Indeed, when I built my project with `--service-pull-request $TRAVIS_PULL_REQUEST`, it generated [a report with a button](https://coveralls.io/builds/27746270) that led to the PR.