### PR TITLE
Set the default number of threads to n_cpu-1

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ use std::{process, thread};
 use grcov::*;
 
 fn main() {
-    let default_num_threads = (num_cpus::get() * 2).to_string();
+    let default_num_threads = 1.max(num_cpus::get() - 1).to_string();
 
     let matches = App::new("grcov")
                           .version(crate_version!())


### PR DESCRIPTION
For the history:
We've OOM when using grcov with a lot of zip files (~500):
 - if not enough workers the queue is growing to much and it implies some data retention
 - if too much workers, then a lot of them have a low priority and then keep some data (buffer+struct containing info) and so lead to a high memory consumption.
So the goal of the patch is to use by default exactly the number of cpus we've: 1 thread for the producer and the others for the consumers.