### PR TITLE
Coveralls: make repo token optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,7 @@ OPTIONS:
     -p, --prefix-dir <PATH>
             Specifies a prefix to remove from the paths (e.g. if grcov is run on a different machine than the one that
             generated the code coverage information)
-        --service-job-id <SERVICE JOB ID>            Sets the service job id
-        --service-job-number <SERVICE JOB NUMBER>    Sets the service job number (deprecated in favour of --service-job-id)
+        --service-job-id <SERVICE JOB ID>            Sets the service job id [aliases: service-job-number]
         --service-name <SERVICE NAME>                Sets the service name
         --service-number <SERVICE NUMBER>            Sets the service number
         --service-pull-request <SERVICE PULL REQUEST>

--- a/src/main.rs
+++ b/src/main.rs
@@ -210,12 +210,12 @@ fn main() {
         None
     };
     let is_llvm = matches.is_present("llvm");
-    let repo_token = matches.value_of("token").unwrap_or("");
+    let repo_token = matches.value_of("token");
     let commit_sha = matches.value_of("commit_sha").unwrap_or("");
-    let service_name = matches.value_of("service_name").unwrap_or("");
+    let service_name = matches.value_of("service_name");
     let is_parallel = matches.is_present("parallel");
     let service_number = matches.value_of("service_number").unwrap_or("");
-    let service_job_id = matches.value_of("service_job_id").unwrap_or("");
+    let service_job_id = matches.value_of("service_job_id");
     let service_pull_request = matches.value_of("service_pull_request").unwrap_or("");
     let vcs_branch = matches.value_of("vcs_branch").unwrap_or("");
     let log = matches.value_of("log").unwrap_or("");

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,19 +135,12 @@ fn main() {
                                .value_name("SERVICE NUMBER")
                                .takes_value(true))
 
-                          .arg(Arg::with_name("service_job_number")
-                               .help("Sets the service job number (deprecated in favour of --service-job-id)")
-                               .long("service-job-number")
-                               .value_name("SERVICE JOB NUMBER")
-                               .takes_value(true)
-                               .conflicts_with("service_job_id"))
-
                           .arg(Arg::with_name("service_job_id")
                                .help("Sets the service job id")
                                .long("service-job-id")
                                .value_name("SERVICE JOB ID")
                                .takes_value(true)
-                               .conflicts_with("service_job_number"))
+                               .visible_alias("service-job-number"))
 
                           .arg(Arg::with_name("service_pull_request")
                                .help("Sets the service pull request number")
@@ -213,10 +206,7 @@ fn main() {
     let service_name = matches.value_of("service_name").unwrap_or("");
     let is_parallel = matches.is_present("parallel");
     let service_number = matches.value_of("service_number").unwrap_or("");
-    let service_job_id = matches
-        .value_of("service_job_id")
-        .or_else(|| matches.value_of("service_job_number"))
-        .unwrap_or("");
+    let service_job_id = matches.value_of("service_job_id").unwrap_or("");
     let service_pull_request = matches.value_of("service_pull_request").unwrap_or("");
     let vcs_branch = matches.value_of("vcs_branch").unwrap_or("");
     let log = matches.value_of("log").unwrap_or("");

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ extern crate serde_json;
 extern crate simplelog;
 extern crate tempfile;
 
-use clap::{crate_authors, crate_version, App, Arg};
+use clap::{crate_authors, crate_version, App, Arg, ArgGroup};
 use crossbeam::crossbeam_channel::unbounded;
 use log::error;
 use rustc_hash::FxHashMap;
@@ -51,7 +51,11 @@ fn main() {
                                .value_name("OUTPUT TYPE")
                                .default_value("lcov")
                                .possible_values(&["ade", "lcov", "coveralls", "coveralls+", "files", "covdir", "html"])
-                               .takes_value(true))
+                               .takes_value(true)
+                               .requires_ifs(&[
+                                   ("coveralls", "coveralls_auth"),
+                                   ("coveralls+", "coveralls_auth")
+                               ]))
 
                           .arg(Arg::with_name("output_file")
                                .help("Specifies the output file")
@@ -111,11 +115,7 @@ fn main() {
                                .help("Sets the repository token from Coveralls, required for the 'coveralls' and 'coveralls+' formats")
                                .long("token")
                                .value_name("TOKEN")
-                               .takes_value(true)
-                               .required_ifs(&[
-                                   ("output_type", "coveralls"),
-                                   ("output_type", "coveralls+")
-                               ]))
+                               .takes_value(true))
 
                           .arg(Arg::with_name("commit_sha")
                                .help("Sets the hash of the commit used to generate the code coverage data")
@@ -140,7 +140,8 @@ fn main() {
                                .long("service-job-id")
                                .value_name("SERVICE JOB ID")
                                .takes_value(true)
-                               .visible_alias("service-job-number"))
+                               .visible_alias("service-job-number")
+                               .requires("service_name"))
 
                           .arg(Arg::with_name("service_pull_request")
                                .help("Sets the service pull request number")
@@ -174,6 +175,14 @@ fn main() {
                                .default_value("stderr")
                                .value_name("LOG")
                                .takes_value(true))
+
+                          // This group requires that at least one of --token and --service-job-id
+                          // be present. --service-job-id requires --service-name, so this
+                          // effectively means we accept the following combinations:
+                          // - --token
+                          // - --token --service-job-id --service-name
+                          // - --service-job-id --service-name
+                          .group(ArgGroup::with_name("coveralls_auth").args(&["token", "service_job_id"]).multiple(true))
 
                           .get_matches();
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -152,6 +152,10 @@ fn run_grcov(paths: Vec<&Path>, source_root: &Path, output_format: &str) -> Stri
     if output_format == "coveralls" {
         args.push("--token");
         args.push("TOKEN");
+        args.push("--service-name");
+        args.push("");
+        args.push("--service-job-id");
+        args.push("");
         args.push("--commit-sha");
         args.push("COMMIT");
         args.push("-s");


### PR DESCRIPTION
[Coveralls docs](https://docs.coveralls.io/api-introduction) state that users can authenticate with either:
- repo token
- service-name and service-job-id

But grcov requires the token. This creates problems for pull requests on Travis CI: the token is usually put into an encrypted variable, but encrypted variables are not set for PRs. Thus, PR builds can't submit coverage.

This PR teaches grcov about Coveralls' requirements, making it possible to submit coverage from Travis both from the main repo and its PRs.

I validated this work with two PRs to my project: https://github.com/newsboat/newsboat/pull/736 and https://github.com/newsboat/newsboat/pull/737. Both submitted coverage and got a comment from Coveralls.