### PR TITLE
Switch to tcmalloc as memory allocator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,16 +106,13 @@ matrix:
 
     - os: osx
       rust: nightly
-      addons:
-        homebrew:
-          packages:
-            - gperftools
       env:
         - CLANG_CXX=clang++
         - DEPLOY=1
 install:
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sudo softwareupdate -i "Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4"; fi
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew cask uninstall --force oclint; fi
+    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install gperftools; fi
 script:
     - $CLANG_CXX --version
     - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,6 +106,10 @@ matrix:
 
     - os: osx
       rust: nightly
+      addons:
+        homebrew:
+          packages:
+            - gperftools
       env:
         - CLANG_CXX=clang++
         - DEPLOY=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
           packages:
             - clang-7
             - g++-5
+            - libgoogle-perftools-dev
       env:
         - GCC_CXX=g++-5
         - GCOV=gcov-5
@@ -28,6 +29,7 @@ matrix:
           packages:
             - clang-7
             - g++-5
+            - libgoogle-perftools-dev
       env:
         - GCC_CXX=g++-5
         - GCOV=gcov-5
@@ -44,6 +46,7 @@ matrix:
           packages:
             - clang-7
             - g++-6
+            - libgoogle-perftools-dev
       env:
         - GCC_CXX=g++-6
         - GCOV=gcov-6
@@ -60,6 +63,7 @@ matrix:
           packages:
             - clang-7
             - g++-7
+            - libgoogle-perftools-dev
       env:
         - GCC_CXX=g++-7
         - GCOV=gcov-7
@@ -76,6 +80,7 @@ matrix:
           packages:
             - clang-8
             - g++-7
+            - libgoogle-perftools-dev
       env:
         - GCC_CXX=g++-7
         - GCOV=gcov-7
@@ -92,6 +97,7 @@ matrix:
           packages:
             - clang
             - g++-7
+            - libgoogle-perftools-dev
       env:
         - GCC_CXX=g++-7
         - GCOV=gcov-7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,6 +398,7 @@ dependencies = [
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tcmalloc 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -788,6 +789,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "tcmalloc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "tempfile"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1018,6 +1024,7 @@ dependencies = [
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
+"checksum tcmalloc 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "375205113d84a1c5eeed67beaa0ce08e41be1a9d5acc3425ad2381fddd9d819b"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum term 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,9 @@ chrono = "^0.4"
 log = "^0.4"
 simplelog = "^0.7"
 
+[target.'cfg(unix)'.dependencies]
+#tcmalloc = { version = "^0.3", features = ["bundled"] }
+tcmalloc = "^0.3"
 
 [dev-dependencies]
 regex = "^1.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
 #[cfg(unix)]
 use tcmalloc::TCMalloc;
 
-#[cfg_attr(unix, global_allocator)]
+#[cfg(unix)]
+#[global_allocator]
 static GLOBAL: TCMalloc = TCMalloc;
 
 extern crate clap;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,9 @@
+#[cfg(unix)]
+use tcmalloc::TCMalloc;
+
+#[cfg_attr(unix, global_allocator)]
+static GLOBAL: TCMalloc = TCMalloc;
+
 extern crate clap;
 extern crate crossbeam;
 extern crate grcov;


### PR DESCRIPTION
We've a kind of memory leak when we've a lot of zip containing big info files.
My guess is that this "leak" is due to memory fragmentation: in lcov parser we allocate a lot of strings, hash_maps and so on.
I've a set of 500 zips and memory use with default allocator the memory use is ~25 Gb when it's ~8Gb with tcmalloc (and for information: ~19Gb with jemalloc).