### PR TITLE
Make tcmalloc optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ exclude = [
 ]
 edition = "2018"
 
+[features]
+default = []
+tc = ["tcmalloc"]
+
 [badges]
 appveyor = { repository = "marco-c/grcov" }
 travis-ci = { repository = "mozilla/grcov" }
@@ -50,7 +54,7 @@ simplelog = "^0.7"
 
 [target.'cfg(unix)'.dependencies]
 #tcmalloc = { version = "^0.3", features = ["bundled"] }
-tcmalloc = "^0.3"
+tcmalloc = { version = "^0.3", optional = true }
 
 [dev-dependencies]
 regex = "^1.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
-#[cfg(unix)]
+#[cfg(feature = "tc")]
 use tcmalloc::TCMalloc;
 
-#[cfg(unix)]
+#[cfg(feature = "tc")]
 #[global_allocator]
 static GLOBAL: TCMalloc = TCMalloc;
 


### PR DESCRIPTION
Add a cargo feature to compile grcov with tcmalloc.
Just run `cargo build --release --features tc` to build with tcmalloc.