### PR TITLE
Remove -Zno-landing-pads flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,7 +118,7 @@ script:
     - |
       if [ "$TRAVIS_RUST_VERSION" = "nightly" ] && [ -z "$TRAVIS_TAG" ]; then
         export CARGO_INCREMENTAL=0;
-        export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off";
+        export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort";
       fi
     - if [ "$TRAVIS_TAG" ]; then export CARGO_OPTIONS="--release"; fi
     - cargo build --verbose $CARGO_OPTIONS

--- a/.travis.yml
+++ b/.travis.yml
@@ -118,7 +118,7 @@ script:
     - |
       if [ "$TRAVIS_RUST_VERSION" = "nightly" ] && [ -z "$TRAVIS_TAG" ]; then
         export CARGO_INCREMENTAL=0;
-        export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort";
+        export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort";
       fi
     - if [ "$TRAVIS_TAG" ]; then export CARGO_OPTIONS="--release"; fi
     - cargo build --verbose $CARGO_OPTIONS

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,6 +119,7 @@ script:
       if [ "$TRAVIS_RUST_VERSION" = "nightly" ] && [ -z "$TRAVIS_TAG" ]; then
         export CARGO_INCREMENTAL=0;
         export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort";
+        export RUSTDOCFLAGS="-Cpanic=abort";
       fi
     - if [ "$TRAVIS_TAG" ]; then export CARGO_OPTIONS="--release"; fi
     - cargo build --verbose $CARGO_OPTIONS

--- a/.travis.yml
+++ b/.travis.yml
@@ -118,7 +118,7 @@ script:
     - |
       if [ "$TRAVIS_RUST_VERSION" = "nightly" ] && [ -z "$TRAVIS_TAG" ]; then
         export CARGO_INCREMENTAL=0;
-        export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads";
+        export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off";
       fi
     - if [ "$TRAVIS_TAG" ]; then export CARGO_OPTIONS="--release"; fi
     - cargo build --verbose $CARGO_OPTIONS

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Pass `--coverage` to `clang` or `gcc` (or for older gcc versions pass `-ftest-co
 
 ```sh
 export CARGO_INCREMENTAL=0
-export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads"
+export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off"
 ```
 These will ensure that things like dead code elimination do not skew the coverage.
 
@@ -158,7 +158,7 @@ matrix:
 
 script:
     - export CARGO_INCREMENTAL=0
-    - export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads"
+    - export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off"
     - cargo build --verbose $CARGO_OPTIONS
     - cargo test --verbose $CARGO_OPTIONS
     - |

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Pass `--coverage` to `clang` or `gcc` (or for older gcc versions pass `-ftest-co
 
 ```sh
 export CARGO_INCREMENTAL=0
-export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off"
+export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort"
 ```
 These will ensure that things like dead code elimination do not skew the coverage.
 
@@ -158,7 +158,7 @@ matrix:
 
 script:
     - export CARGO_INCREMENTAL=0
-    - export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off"
+    - export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort"
     - cargo build --verbose $CARGO_OPTIONS
     - cargo test --verbose $CARGO_OPTIONS
     - |

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Pass `--coverage` to `clang` or `gcc` (or for older gcc versions pass `-ftest-co
 ```sh
 export CARGO_INCREMENTAL=0
 export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
+export RUSTDOCFLAGS="-Cpanic=abort"
 ```
 These will ensure that things like dead code elimination do not skew the coverage.
 
@@ -159,6 +160,7 @@ matrix:
 script:
     - export CARGO_INCREMENTAL=0
     - export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
+    - export RUSTDOCFLAGS="-Cpanic=abort"
     - cargo build --verbose $CARGO_OPTIONS
     - cargo test --verbose $CARGO_OPTIONS
     - |

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Pass `--coverage` to `clang` or `gcc` (or for older gcc versions pass `-ftest-co
 
 ```sh
 export CARGO_INCREMENTAL=0
-export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort"
+export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
 ```
 These will ensure that things like dead code elimination do not skew the coverage.
 
@@ -158,7 +158,7 @@ matrix:
 
 script:
     - export CARGO_INCREMENTAL=0
-    - export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort"
+    - export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
     - cargo build --verbose $CARGO_OPTIONS
     - cargo test --verbose $CARGO_OPTIONS
     - |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,7 @@ build_script:
   - ps: |
       If ($env:CHANNEL -eq "nightly" -And $env:APPVEYOR_REPO_TAG -eq "false") {
          $env:CARGO_INCREMENTAL = "0"
-         $env:RUSTFLAGS = "-Zprofile -Ccodegen-units=1 -Ctarget-feature=+crt-static -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort"
+         $env:RUSTFLAGS = "-Zprofile -Ccodegen-units=1 -Ctarget-feature=+crt-static -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
       }
   - cargo build %CARGO_RELEASE_ARG% --locked --target %TARGET%
   - 7z a grcov-win-%PLATFORM_TARGET%.tar .\target\%TARGET%\%BUILD_TYPE%\grcov.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,7 @@ build_script:
   - ps: |
       If ($env:CHANNEL -eq "nightly" -And $env:APPVEYOR_REPO_TAG -eq "false") {
          $env:CARGO_INCREMENTAL = "0"
-         $env:RUSTFLAGS = "-Zprofile -Ccodegen-units=1 -Ctarget-feature=+crt-static -Zno-landing-pads -Copt-level=0 -Clink-dead-code -Coverflow-checks=off"
+         $env:RUSTFLAGS = "-Zprofile -Ccodegen-units=1 -Ctarget-feature=+crt-static -Copt-level=0 -Clink-dead-code -Coverflow-checks=off"
       }
   - cargo build %CARGO_RELEASE_ARG% --locked --target %TARGET%
   - 7z a grcov-win-%PLATFORM_TARGET%.tar .\target\%TARGET%\%BUILD_TYPE%\grcov.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,7 @@ build_script:
   - ps: |
       If ($env:CHANNEL -eq "nightly" -And $env:APPVEYOR_REPO_TAG -eq "false") {
          $env:CARGO_INCREMENTAL = "0"
-         $env:RUSTFLAGS = "-Zprofile -Ccodegen-units=1 -Ctarget-feature=+crt-static -Copt-level=0 -Clink-dead-code -Coverflow-checks=off"
+         $env:RUSTFLAGS = "-Zprofile -Ccodegen-units=1 -Ctarget-feature=+crt-static -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort"
       }
   - cargo build %CARGO_RELEASE_ARG% --locked --target %TARGET%
   - 7z a grcov-win-%PLATFORM_TARGET%.tar .\target\%TARGET%\%BUILD_TYPE%\grcov.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,6 +45,7 @@ build_script:
       If ($env:CHANNEL -eq "nightly" -And $env:APPVEYOR_REPO_TAG -eq "false") {
          $env:CARGO_INCREMENTAL = "0"
          $env:RUSTFLAGS = "-Zprofile -Ccodegen-units=1 -Ctarget-feature=+crt-static -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
+         $env:RUSTDOCFLAGS = "-Cpanic=abort"
       }
   - cargo build %CARGO_RELEASE_ARG% --locked --target %TARGET%
   - 7z a grcov-win-%PLATFORM_TARGET%.tar .\target\%TARGET%\%BUILD_TYPE%\grcov.exe


### PR DESCRIPTION
Fix #427 
Remove `-Zno-landing-pads` in README instructions and CI files since this flag is no longer exist.
