### PR TITLE
Pre commit ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
         language: system
         types: [file, rust]
         entry: cargo fmt -- --check
+        pass_filenames: false
 
       - id: clippy
         name: clippy
@@ -33,9 +34,9 @@ repos:
       - id: test
         name: test
         language: system
-        files: '\.rs$'
+        types: [file, rust]
         entry: cargo test --lib
         pass_filenames: false
 
 default_language_version:
-    python: python3.7
+    python: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
         name: clippy
         language: system
         types: [file, rust]
-        entry: cargo clippy --all-targets --all # -- -D warnings # Use -D warnings option to ensure the job fails when encountering warnings
+        entry: cargo clippy --bins --tests --examples --all # -- -D warnings # Use -D warnings option to ensure the job fails when encountering warnings
         pass_filenames: false
 
       - id: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -123,7 +123,7 @@ matrix:
             - python3-wheel
       script:
         - rustup component add rustfmt clippy
-        - pip3 install pre-commit
+        - pip3 install --disable-pip-version-check --quiet --no-cache-dir pre-commit
         - pre-commit run --all-files
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,23 @@ matrix:
       env:
         - CLANG_CXX=clang++
         - DEPLOY=1
+
+    - os: linux
+      rust: stable
+      dist: bionic
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - python3-pip
+            - python3-setuptools
+            - python3-wheel
+      script:
+        - rustup component add rustfmt clippy
+        - pip3 install pre-commit
+        - pre-commit run --all-files
+
 install:
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sudo softwareupdate -i "Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4"; fi
     - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew cask uninstall --force oclint; fi


### PR DESCRIPTION
Closes #302 

Technically also related to #127, though we can also add a separate nightly clippy job that is allowed to fail and includes the benchmarks. To close it you probably want to fix clippy warnings.

I had to disable benchmarks in clippy because of the:
```error[E0554]: #![feature] may not be used on the stable release channel```

Let me know what you think, cheers.