### PR TITLE
Show branch coverage in the html report

### DIFF
--- a/resources/grcov.css
+++ b/resources/grcov.css
@@ -1,3 +1,7 @@
+* {
+  box-sizing: border-box;
+}
+
 body {
     color: #000000;
     background-color: #FFFFFF;
@@ -110,11 +114,13 @@ body {
     font-family: sans-serif;
 }
 
-.statsLine, .statsFun {
+.statsLine, .statsFun, .statsBranches {
     font-weight: bold;
 }
 
-.linesHit, .linesTotal, .linesPercentage, .funsHit, .funsTotal, .funsPercentage {
+.linesHit, .linesTotal, .linesPercentage,
+.funsHit, .funsTotal, .funsPercentage,
+.branchesHit, .branchesTotal, .branchesPercentage {
     background-color: #DAE7FE;
     color: #284FA8;
     white-space: nowrap;
@@ -123,7 +129,7 @@ body {
     font-weight: bold;
 }
 
-.linesPercentage, .funsPercentage {
+.linesPercentage, .funsPercentage, .branchesPercentage {
     color: black;
 }
 
@@ -137,15 +143,15 @@ body {
   white-space: nowrap;
 }
 
-.funHi, .lineHi {
+.funHi, .lineHi, .branchHi {
     background-color: #A7FC9D;
 }
 
-.funMed, .lineMed {
+.funMed, .lineMed, .branchMed {
     background-color: #FFEA20;
 }
 
-.funLow, .lineLow {
+.funLow, .lineLow, .branchLow {
     background-color: #FF0000;
 }
 
@@ -203,35 +209,39 @@ body {
     text-align: center;
 }
 
-.dirLinesPer, .dirLinesRatio, .dirFunsPer, .dirFunsRatio {
+.dirLinesPer, .dirLinesRatio,
+.dirFunsPer, .dirFunsRatio,
+.dirBranchesPer, .dirBranchesRatio {
     text-align: right;
     padding-right: 1em;
 }
 
-.dirBarPer, .dirLinesPer, .dirLinesRatio, .dirFunsPer, .dirFunsRatio {
-    width: 10%;
+.dirBarPer, .dirLinesPer, .dirLinesRatio,
+.dirFunsPer, .dirFunsRatio,
+.dirBranchesPer, .dirBranchesRatio {
+    width: 8%;
 }
 
-.dirLinesPer, .dirFunsPer {
+.dirLinesPer, .dirFunsPer, .dirBranchesPer {
     font-weight: bold;
 }
 
-.dirLineCovHeader, .dirNameHeader, .dirFunsHeader {
+.dirLineCovHeader, .dirNameHeader, .dirFunsHeader, .dirBranchesHeader {
     text-align: center;
 }
 
 .dirLineCovHeader {
-    width: 30%;
+    width: 24%;
     padding-left: 1em;
 }
 
-.dirFunsHeader {
-    width: 20%;
+.dirFunsHeader, .dirBranchesHeader {
+    width: 16%;
     padding-left: 1em;
 }
 
 .dirName, .dirNameHeader {
-    width: 50%;
+    width: 44%;
     padding-left: 1em;
 }
 

--- a/src/defs.rs
+++ b/src/defs.rs
@@ -93,6 +93,8 @@ pub struct HtmlStats {
     pub covered_lines: usize,
     pub total_funs: usize,
     pub covered_funs: usize,
+    pub total_branches: usize,
+    pub covered_branches: usize,
 }
 
 #[derive(Clone, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -483,7 +483,7 @@ fn main() {
     } else if output_type == "covdir" {
         output_covdir(iterator, output_path);
     } else if output_type == "html" {
-        output_html(iterator, output_path, num_threads);
+        output_html(iterator, output_path, num_threads, branch_enabled);
     } else {
         assert!(false, "{} is not a supported output type", output_type);
     }

--- a/src/output.rs
+++ b/src/output.rs
@@ -475,7 +475,12 @@ pub fn output_files(results: CovResultIter, output_file: Option<&str>) {
     }
 }
 
-pub fn output_html(results: CovResultIter, output_dir: Option<&str>, num_threads: usize) {
+pub fn output_html(
+    results: CovResultIter,
+    output_dir: Option<&str>,
+    num_threads: usize,
+    branch_enabled: bool,
+) {
     let output = if let Some(output_dir) = output_dir {
         PathBuf::from(output_dir)
     } else {
@@ -505,7 +510,7 @@ pub fn output_html(results: CovResultIter, output_dir: Option<&str>, num_threads
         let t = thread::Builder::new()
             .name(format!("Consumer HTML {}", i))
             .spawn(move || {
-                html::consumer_html(receiver, stats, output, config);
+                html::consumer_html(receiver, stats, output, config, branch_enabled);
             })
             .unwrap();
 
@@ -534,7 +539,7 @@ pub fn output_html(results: CovResultIter, output_dir: Option<&str>, num_threads
 
     let global = Arc::try_unwrap(stats).unwrap().into_inner().unwrap();
 
-    html::gen_index(global, config, &output);
+    html::gen_index(global, config, &output, branch_enabled);
     html::write_static_files(output);
 }
 


### PR DESCRIPTION
Resolves #445 

**With `--branch`:**
![Screenshot_2020-06-19 Grcov report —src(1)](https://user-images.githubusercontent.com/11539300/85173081-6c216380-b240-11ea-9056-b5317eb5d7f6.png)

**Without:**
![Screenshot_2020-06-19 Grcov report —src(2)](https://user-images.githubusercontent.com/11539300/85173106-75123500-b240-11ea-958e-277a56d209fc.png)

I'm not sure why the line counts are slightly different between the two examples, but I don't think that's related to the changes made here.