### PR TITLE
Use all compiled binaries for source-based coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -178,7 +178,7 @@ script:
     - LLVM_PROFILE_FILE="grcov-%p-%m.profraw" cargo test --verbose $CARGO_OPTIONS
     - |
       if [ "$TRAVIS_RUST_VERSION" = "nightly" ] && [ -z "$TRAVIS_TAG" ]; then
-        ./target/debug/grcov `find . \( -name "grcov-*.profraw" \) -print` --binary-path ./target/debug/grcov -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info;
+        ./target/debug/grcov `find . \( -name "grcov-*.profraw" \) -print` --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info;
         bash <(curl -s https://codecov.io/bash) -f lcov.info;
       fi
     - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -178,7 +178,7 @@ script:
     - LLVM_PROFILE_FILE="grcov-%p-%m.profraw" cargo test --verbose $CARGO_OPTIONS
     - |
       if [ "$TRAVIS_RUST_VERSION" = "nightly" ] && [ -z "$TRAVIS_TAG" ]; then
-        ./target/debug/grcov `find . \( -name "grcov-*.profraw" \) -print` --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info;
+        cargo run --release -- `find . \( -name "grcov-*.profraw" \) -print` --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info;
         bash <(curl -s https://codecov.io/bash) -f lcov.info;
       fi
     - |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,6 +445,7 @@ dependencies = [
  "crossbeam",
  "fomat-macros",
  "globset",
+ "is_executable",
  "log",
  "md-5",
  "num_cpus",
@@ -470,6 +471,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "is_executable"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "302d553b8abc8187beb7d663e34c065ac4570b273bc9511a50e940e99409c577"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ simplelog = "^0.7"
 regex = "^1.4"
 rayon = "^1.3"
 cargo-binutils = "^0.3"
+is_executable = "^0.1"
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ FLAGS:
 
 OPTIONS:
     -b, --binary-path <PATH>
-            Sets the path to the compiled binary to be used
+            Sets the path to the directory containing the compiled binaries to be used
 
         --commit-sha <COMMIT HASH>
             Sets the hash of the commit used to generate the code coverage data
@@ -176,7 +176,7 @@ export RUSTFLAGS="-Zinstrument-coverage"
 
 `cargo test`
 
-In the CWD, you will see a `.profraw` file has been generated. This contains the profiling information that grcov will parse, alongside with your binary.
+In the CWD, you will see a `.profraw` file has been generated. This contains the profiling information that grcov will parse, alongside with your binaries.
 
 ### Example: How to generate .gcda files for from C/C++
 
@@ -211,7 +211,7 @@ In the `target/debug/deps/` dir you will now also see `.gcda` files. These conta
 Generate a html coverage report like this:
 
 ```sh
-grcov . -s . --binary-path ./target/debug/YOUR_BINARY -t html --branch --ignore-not-existing -o ./target/debug/coverage/
+grcov . -s . --binary-path ./target/debug/ -t html --branch --ignore-not-existing -o ./target/debug/coverage/
 ```
 
 N.B.: The `--binary-path` argument is only necessary for source-based coverage.
@@ -233,7 +233,7 @@ genhtml -o ./target/debug/coverage/ --show-details --highlight --ignore-errors s
 Coverage can also be generated in coveralls format:
 
 ```sh
-grcov . --binary-path ./target/debug/YOUR_BINARY -t coveralls -s . --token YOUR_COVERALLS_TOKEN > coveralls.json
+grcov . --binary-path ./target/debug/ -t coveralls -s . --token YOUR_COVERALLS_TOKEN > coveralls.json
 ```
 
 #### grcov with Travis
@@ -255,7 +255,7 @@ script:
     - export RUSTFLAGS="-Zinstrument-coverage"
     - cargo build --verbose
     - LLVM_PROFILE_FILE="your_name-%p-%m.profraw" cargo test --verbose
-    - ./grcov . --binary-path ./target/debug/YOUR_BINARY -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info
+    - ./grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info
     - bash <(curl -s https://codecov.io/bash) -f lcov.info
 ```
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,7 +56,7 @@ test_script:
       If ($env:CHANNEL -eq "nightly" -And $env:APPVEYOR_REPO_TAG -eq "false") {
          mkdir ccov_dir
          Get-ChildItem -Path *\grcov*.profraw -Recurse | Copy-Item -Destination ccov_dir
-         .\target\debug\grcov ccov_dir --binary-path .\target\debug\grcov.exe -s . -t lcov --branch --ignore-not-existing --ignore "C:*" -o lcov.info
+         .\target\debug\grcov ccov_dir --binary-path .\target\debug\ -s . -t lcov --branch --ignore-not-existing --ignore "C:*" -o lcov.info
          (Get-Content lcov.info) | Foreach-Object {$_ -replace "\xEF\xBB\xBF", ""} | Set-Content lcov.info
          ((Get-Content lcov.info) -join "`n") + "`n" | Set-Content -NoNewline lcov.info
          $env:PATH = "C:\msys64\usr\bin;" + $env:PATH

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,7 +56,7 @@ test_script:
       If ($env:CHANNEL -eq "nightly" -And $env:APPVEYOR_REPO_TAG -eq "false") {
          mkdir ccov_dir
          Get-ChildItem -Path *\grcov*.profraw -Recurse | Copy-Item -Destination ccov_dir
-         .\target\debug\grcov ccov_dir --binary-path .\target\debug\ -s . -t lcov --branch --ignore-not-existing --ignore "C:*" -o lcov.info
+         cargo run --release -- ccov_dir --binary-path .\target\debug\ -s . -t lcov --branch --ignore-not-existing --ignore "C:*" -o lcov.info
          (Get-Content lcov.info) | Foreach-Object {$_ -replace "\xEF\xBB\xBF", ""} | Set-Content lcov.info
          ((Get-Content lcov.info) -join "`n") + "`n" | Set-Content -NoNewline lcov.info
          $env:PATH = "C:\msys64\usr\bin;" + $env:PATH

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,7 +168,7 @@ pub fn consumer(
     receiver: JobReceiver,
     branch_enabled: bool,
     guess_directory: bool,
-    binary_path: &Option<String>,
+    binary_path: &Option<PathBuf>,
 ) {
     let mut gcov_type = GcovType::Unknown;
 
@@ -267,7 +267,18 @@ pub fn consumer(
                         binary_path.as_ref().unwrap(),
                         working_dir,
                     ) {
-                        Ok(lcov) => try_parse!(parse_lcov(lcov, branch_enabled), work_item.name),
+                        Ok(lcovs) => {
+                            let mut new_results: Vec<(String, CovResult)> = Vec::new();
+
+                            for lcov in lcovs {
+                                new_results.append(&mut try_parse!(
+                                    parse_lcov(lcov, branch_enabled),
+                                    work_item.name
+                                ));
+                            }
+
+                            new_results
+                        }
                         Err(e) => {
                             error!("Error while executing llvm tools: {}", e);
                             continue;

--- a/src/main.rs
+++ b/src/main.rs
@@ -250,7 +250,7 @@ fn main() {
     let paths: Vec<_> = matches.values_of("paths").unwrap().collect();
     let paths: Vec<String> = paths.iter().map(|s| s.to_string()).collect();
     let binary_path = if let Some(binary_path) = matches.value_of("binary_path") {
-        Some(binary_path.to_string())
+        Some(PathBuf::from(binary_path))
     } else {
         None
     };


### PR DESCRIPTION
This solution isn't perfect as it will run it on all binaries, no matter what, while the best option would be to match the profraw with the right binary.
That's not easy though. We have the possibility of having a "binary signature" in profraw files, but it is not easy to compute: https://github.com/llvm/llvm-project/blob/64ada7accbcccf1ef3ac4910d596e890570c64b2/compiler-rt/lib/profile/InstrProfilingMerge.c#L22-L37 (many of those __llvm_profile functions are platform-specific).