### PR TITLE
Revert "Run cargo in release mode to parse artifacts"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -205,7 +205,7 @@ script:
     - LLVM_PROFILE_FILE="grcov-%p-%m.profraw" cargo test --verbose $CARGO_OPTIONS
     - |
       if [ "$TRAVIS_RUST_VERSION" = "nightly" ] && [ -z "$TRAVIS_TAG" ]; then
-        cargo run --release -- `find . \( -name "grcov-*.profraw" \) -print` --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info;
+        ./target/debug/grcov `find . \( -name "grcov-*.profraw" \) -print` --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info;
         bash <(curl -s https://codecov.io/bash) -f lcov.info;
       fi
     - |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,7 +56,7 @@ test_script:
       If ($env:CHANNEL -eq "nightly" -And $env:APPVEYOR_REPO_TAG -eq "false") {
          mkdir ccov_dir
          Get-ChildItem -Path *\grcov*.profraw -Recurse | Copy-Item -Destination ccov_dir
-         cargo run --release -- ccov_dir --binary-path .\target\debug\ -s . -t lcov --branch --ignore-not-existing --ignore "C:*" -o lcov.info
+         .\target\debug\grcov ccov_dir --binary-path .\target\debug\ -s . -t lcov --branch --ignore-not-existing --ignore "C:*" -o lcov.info
          (Get-Content lcov.info) | Foreach-Object {$_ -replace "\xEF\xBB\xBF", ""} | Set-Content lcov.info
          ((Get-Content lcov.info) -join "`n") + "`n" | Set-Content -NoNewline lcov.info
          $env:PATH = "C:\msys64\usr\bin;" + $env:PATH


### PR DESCRIPTION
This reverts commit 155c73f05c67f173c75946b07e22b9d53f65d647.

The workaround is no longer needed since d8525623bb0a277ee621cd6b170006d36865661c.

Fixes #525