### PR TITLE
Use thin-lto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ flate2 = "^1.0"
 lazy_static = "^1.3"
 
 [profile.release]
-lto = true
+lto = "thin"
 
 [target.'cfg(unix)'.dependencies]
 #tcmalloc = { version = "^0.3", features = ["bundled"] }


### PR DESCRIPTION
It halves the compilation time while does not change the execution time
in a significant way.

lto
    Finished release [optimized] target(s) in 1m 12s
thin-lto
    Finished release [optimized] target(s) in 33.37s

Benchmark #1: master-lto/release/grcov ~/Samples/grcov/code-coverage-*.zip -t lcov --branch -o lcov.info
  Time (mean ± σ):     14.717 s ±  0.493 s    [User: 16.280 s, System: 1.547 s]
  Range (min … max):   14.368 s … 15.066 s    2 runs

Benchmark #2: master-lto-thin/release/grcov ~/Samples/grcov/code-coverage-*.zip -t lcov --branch -o lcov.info
  Time (mean ± σ):     14.774 s ±  0.112 s    [User: 16.437 s, System: 1.509 s]
  Range (min … max):   14.695 s … 14.854 s    2 runs