### PR TITLE
No swift demangling by default since it requires a c++ compiler.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ exclude = [
 edition = "2018"
 
 [features]
-default = ["deflate-zlib", "demangle-with-swift"]
+default = ["deflate-zlib", "demangle-no-swift"]
 tc = ["tcmalloc"]
 deflate = ["zip/deflate"]
 deflate-miniz = ["zip/deflate-miniz"]


### PR DESCRIPTION
User will have to pass "--features 'demangle-with-swift'" to enable it.