### PR TITLE
Add a clearer error message when output fails

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -45,8 +45,17 @@ pub fn get_target_output_writable(output_file: Option<&str>) -> Box<dyn Write> {
                     filename
                 )
             }
-            Box::new(File::create(output).unwrap_or_else(|_| {
-                panic!("Cannot create the file {} to dump coverage data. Check if parent directory exists.", filename)
+            Box::new(File::create(&output).unwrap_or_else(|_| {
+                let parent = output.parent();
+                if let Some(filepath) = parent {
+                    if !filepath.exists() {
+                        panic!(
+                            "Cannot create {} to dump coverage data, as {} doesn't exist",
+                            filename, filepath.display()
+                        )
+                    }
+                }
+                panic!("Cannot create the file {} to dump coverage data.", filename)
             }))
         }
         None => {

--- a/src/output.rs
+++ b/src/output.rs
@@ -46,7 +46,7 @@ pub fn get_target_output_writable(output_file: Option<&str>) -> Box<dyn Write> {
                 )
             }
             Box::new(File::create(output).unwrap_or_else(|_| {
-                panic!("Cannot create the file {} to dump coverage data", filename)
+                panic!("Cannot create the file {} to dump coverage data. Check if parent directory exists.", filename)
             }))
         }
         None => {

--- a/src/output.rs
+++ b/src/output.rs
@@ -47,11 +47,11 @@ pub fn get_target_output_writable(output_file: Option<&str>) -> Box<dyn Write> {
             }
             Box::new(File::create(&output).unwrap_or_else(|_| {
                 let parent = output.parent();
-                if let Some(filepath) = parent {
-                    if !filepath.exists() {
+                if let Some(parent_path) = parent {
+                    if !parent_path.exists() {
                         panic!(
                             "Cannot create {} to dump coverage data, as {} doesn't exist",
-                            filename, filepath.display()
+                            filename, parent_path.display()
                         )
                     }
                 }


### PR DESCRIPTION
because target directory doesn't exist

Fix #481

Add a clear error message when output fails if directory doesn't exist