### PR TITLE
Avoid calling `Tool::Cov.path` multiple times

### DIFF
--- a/src/llvm_tools.rs
+++ b/src/llvm_tools.rs
@@ -1,11 +1,11 @@
 use cargo_binutils::Tool;
 use is_executable::IsExecutable;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use walkdir::WalkDir;
 
-pub fn run(cmd: PathBuf, args: &[&str]) -> Result<Vec<u8>, String> {
+pub fn run(cmd: &Path, args: &[&str]) -> Result<Vec<u8>, String> {
     let mut command = Command::new(cmd);
     command.args(args);
     let output = match command.output() {
@@ -55,6 +55,7 @@ pub fn profraws_to_lcov(
     };
 
     let mut results = vec![];
+    let cov_tool_path = Tool::Cov.path().unwrap();
 
     for binary in binaries {
         let args = [
@@ -66,7 +67,7 @@ pub fn profraws_to_lcov(
             "lcov",
         ];
 
-        if let Ok(result) = run(Tool::Cov.path().unwrap(), &args) {
+        if let Ok(result) = run(&cov_tool_path, &args) {
             results.push(result);
         }
     }

--- a/src/llvm_tools.rs
+++ b/src/llvm_tools.rs
@@ -21,13 +21,13 @@ pub fn run(cmd: &Path, args: &[&OsStr]) -> Result<Vec<u8>, String> {
         ));
     }
 
-    return Ok(output.stdout);
+    Ok(output.stdout)
 }
 
 pub fn profraws_to_lcov(
     profraw_paths: &[PathBuf],
-    binary_path: &PathBuf,
-    working_dir: &PathBuf,
+    binary_path: &Path,
+    working_dir: &Path,
 ) -> Result<Vec<Vec<u8>>, String> {
     let profdata_path = working_dir.join("grcov.profdata");
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -51,7 +51,8 @@ pub fn get_target_output_writable(output_file: Option<&str>) -> Box<dyn Write> {
                     if !parent_path.exists() {
                         panic!(
                             "Cannot create {} to dump coverage data, as {} doesn't exist",
-                            filename, parent_path.display()
+                            filename,
+                            parent_path.display()
                         )
                     }
                 }


### PR DESCRIPTION
A single `Tool::Cov.path()` call takes more than 300 ms to finish on my Windows PC on average. I have found out that for one of my projects, the total time took by `Tool::Cov.path()` is more than 30 seconds, which is too slow, so I think the call should stay outside of the loop to perform better.

This PR also fixes some Clippy warnings, replaces some `str` with `OsStr` to avoid unnecessary `unwrap()` calls, and fixes a source code format error.