### PR TITLE
Generate code coverage badges for HTML output

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,42 @@ grcov provides the following output types:
 | coveralls+     | Like coveralls but with function level information. |
 | files          | Output a file list of covered or uncovered source files. |
 | covdir         | Provides coverage in a recursive JSON format. |
-| html           | Output a HTML coverage report. |
+| html           | Output a HTML coverage report, including coverage badges for your README. |
+
+### Hosting HTML reports and using coverage badges
+
+The HTML report can be hosted on static website providers like GitHub Pages, Netlify and others. It
+is common to provide a coverage badge in a project's readme to show the current percentage of
+covered code.
+
+To still allow adding the badge when using a static site host, grcov generates coverage badges and
+a JSON file with coverage information that can be used with <https://shields.io> to dynamically
+generate badges.
+
+The coverage data for <htttps://shields.io> can be found at `/coverage.json` and the generated
+bagdes are available as SVGs at `/badges/*svg`.
+
+The design of generated badges is taken from `shields.io` but may not be updated immediately if there
+is any change. Using their endpoint method is recommended if other badges from their service are
+used already.
+
+#### Example
+
+Let's consider we have a project at with username `sample` and project `awesome` that is hosted with
+GitHub Pages at `https://sample.github.io/awesome`.
+
+By using the the `shields.io` endpoint we can create a Markdown badge like so:
+
+```md
+[![coverage](https://shields.io/endpoint?url=https://sample.github.io/awesome/coverage.json)](https://sample.github.io/awesome/index.html)
+```
+
+If we want to avoid using `shields.io` as well, we can use the generated badges as follows (note
+the different URL for the image):
+
+```md
+[![coverage](https://sample.github.io/awesome/badges/flat.svg)](https://sample.github.io/awesome/index.html)
+```
 
 ## Auto-formatting
 

--- a/src/html.rs
+++ b/src/html.rs
@@ -474,7 +474,7 @@ pub fn gen_badge(tera: &Tera, stats: &HtmlStats, conf: &Config, output: &Path, s
 /// using the following URL to generate a covergage badge:
 ///
 /// ```text
-/// https://shields.io/endpoint?url=https://<username>.github.io/<project?>/coveragejson
+/// https://shields.io/endpoint?url=https://<username>.github.io/<project>/coverage.json
 /// ```
 ///
 /// `<username>` and `<project>` should be replaced with a real username and project name

--- a/src/html.rs
+++ b/src/html.rs
@@ -1,10 +1,12 @@
 use chrono::{DateTime, Utc};
+use serde::Serialize;
 use serde_json::value::{from_value, to_value, Value};
+use std::array;
 use std::collections::HashMap;
 use std::collections::{btree_map, BTreeMap};
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use tera::try_get_value;
 
@@ -56,6 +58,26 @@ pub fn get_config() -> (Tera, Config) {
         ("base.html", include_str!("templates/base.html")),
         ("index.html", include_str!("templates/index.html")),
         ("file.html", include_str!("templates/file.html")),
+        (
+            BadgeStyle::Flat.template_name(),
+            include_str!("templates/badges/flat.svg"),
+        ),
+        (
+            BadgeStyle::FlatSquare.template_name(),
+            include_str!("templates/badges/flat_square.svg"),
+        ),
+        (
+            BadgeStyle::ForTheBadge.template_name(),
+            include_str!("templates/badges/for_the_badge.svg"),
+        ),
+        (
+            BadgeStyle::Plastic.template_name(),
+            include_str!("templates/badges/plastic.svg"),
+        ),
+        (
+            BadgeStyle::Social.template_name(),
+            include_str!("templates/badges/social.svg"),
+        ),
     ])
     .unwrap();
 
@@ -196,8 +218,8 @@ fn make_context() -> Context {
 
 pub fn gen_index(
     tera: &Tera,
-    global: HtmlGlobalStats,
-    conf: Config,
+    global: &HtmlGlobalStats,
+    conf: &Config,
     output: &PathBuf,
     branch_enabled: bool,
 ) {
@@ -371,5 +393,131 @@ pub fn consumer_html(
             global.clone(),
             branch_enabled,
         );
+    }
+}
+
+/// Different available styles to render badges with [`gen_badge`].
+#[derive(Clone, Copy)]
+pub enum BadgeStyle {
+    Flat,
+    FlatSquare,
+    ForTheBadge,
+    Plastic,
+    Social,
+}
+
+impl BadgeStyle {
+    /// Name of the template as registered with Tera.
+    fn template_name(self) -> &'static str {
+        match self {
+            Self::Flat => "badge_flat.svg",
+            Self::FlatSquare => "badge_flat_square.svg",
+            Self::ForTheBadge => "badge_for_the_badge.svg",
+            Self::Plastic => "badge_plastic.svg",
+            Self::Social => "badge_social.svg",
+        }
+    }
+
+    /// Output path where the generator writes the file to.
+    fn path(self) -> &'static Path {
+        Path::new(match self {
+            Self::Flat => "badges/flat.svg",
+            Self::FlatSquare => "badges/flat_square.svg",
+            Self::ForTheBadge => "badges/for_the_badge.svg",
+            Self::Plastic => "badges/plastic.svg",
+            Self::Social => "badges/social.svg",
+        })
+    }
+
+    /// Create an iterator over all possible values of this enum.
+    pub fn iter() -> impl Iterator<Item = Self> {
+        array::IntoIter::new([
+            Self::Flat,
+            Self::FlatSquare,
+            Self::ForTheBadge,
+            Self::Plastic,
+            Self::Social,
+        ])
+    }
+}
+
+/// Generate coverage badges, typically for use in a README.md if the HTML output is hosted on a
+/// website like GitHub Pages.
+pub fn gen_badge(tera: &Tera, stats: &HtmlStats, conf: &Config, output: &Path, style: BadgeStyle) {
+    let output_file = output.join(style.path());
+    create_parent(&output_file);
+    let mut output_stream = match File::create(&output_file) {
+        Err(_) => {
+            eprintln!("Cannot create file {:?}", output_file);
+            return;
+        }
+        Ok(f) => f,
+    };
+
+    let mut ctx = make_context();
+    ctx.insert("current", &(stats.covered_lines * 100 / stats.total_lines));
+    ctx.insert("hi_limit", &conf.hi_limit);
+    ctx.insert("med_limit", &conf.med_limit);
+
+    let out = tera.render(style.template_name(), &ctx).unwrap();
+
+    if output_stream.write_all(out.as_bytes()).is_err() {
+        eprintln!("Cannot write the file {:?}", output_file);
+    }
+}
+
+/// Generate a coverage.json file that can be used with shields.io/endpoint to dynamically create
+/// badges from the contained information.
+///
+/// For example, when hosting the coverage output on GitHub Pages, the file would be available at
+/// `https://<username>.github.io/<project>/coverage.json` and could be used with shields.io by
+/// using the following URL to generate a covergage badge:
+///
+/// ```text
+/// https://shields.io/endpoint?url=https://<username>.github.io/<project?>/coveragejson
+/// ```
+///
+/// `<username>` and `<project>` should be replaced with a real username and project name
+/// respectively, for the URL to work.
+pub fn gen_coverage_json(stats: &HtmlStats, conf: &Config, output: &Path) {
+    #[derive(Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct CoverageData {
+        schema_version: u32,
+        label: &'static str,
+        message: String,
+        color: &'static str,
+    }
+
+    let output_file = output.join("coverage.json");
+    create_parent(&output_file);
+    let mut output_stream = match File::create(&output_file) {
+        Err(_) => {
+            eprintln!("Cannot create file {:?}", output_file);
+            return;
+        }
+        Ok(f) => f,
+    };
+
+    let coverage = stats.covered_lines * 100 / stats.total_lines;
+
+    let res = serde_json::to_writer(
+        &mut output_stream,
+        &CoverageData {
+            schema_version: 1,
+            label: "coverage",
+            message: format!("{}%", coverage),
+            color: if coverage as f64 >= conf.hi_limit {
+                "green"
+            } else if coverage as f64 >= conf.med_limit {
+                "yellow"
+            } else {
+                "red"
+            },
+        },
+    );
+
+    if res.is_err() {
+        eprintln!("cannot write the file {:?}", output_file);
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -51,7 +51,8 @@ pub fn get_target_output_writable(output_file: Option<&str>) -> Box<dyn Write> {
                     if !parent_path.exists() {
                         panic!(
                             "Cannot create {} to dump coverage data, as {} doesn't exist",
-                            filename, parent_path.display()
+                            filename,
+                            parent_path.display()
                         )
                     }
                 }
@@ -574,7 +575,13 @@ pub fn output_html(
 
     let global = Arc::try_unwrap(stats).unwrap().into_inner().unwrap();
 
-    html::gen_index(&tera, global, config, &output, branch_enabled);
+    html::gen_index(&tera, &global, &config, &output, branch_enabled);
+
+    for style in html::BadgeStyle::iter() {
+        html::gen_badge(&tera, &global.stats, &config, &output, style);
+    }
+
+    html::gen_coverage_json(&global.stats, &config, &output);
 }
 
 #[cfg(test)]

--- a/src/templates/badges/flat.svg
+++ b/src/templates/badges/flat.svg
@@ -1,0 +1,44 @@
+{# Original badge design by https://github.com/badges/shields under the CC0-1.0 license. #}
+{%- if current >= 100 -%}
+    {%- set width = 104 -%}
+    {%- set position = 815 -%}
+    {%- set text_length = 330 -%}
+{%- elif current >= 10 -%}
+    {%- set width = 96 -%}
+    {%- set position = 775 -%}
+    {%- set text_length = 250 -%}
+{%- else -%}
+    {%- set width = 90 -%}
+    {%- set position = 745 -%}
+    {%- set text_length = 190 -%}
+{%- endif -%}
+{%- if current >= hi_limit -%}
+    {%- set color = "#97ca00" -%}
+{%- elif current >= med_limit -%}
+    {%- set color = "#dfb317" -%}
+{%- else -%}
+    {%- set color = "#e05d44" -%}
+{%- endif -%}
+<svg xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink" width="{{width}}" height="20" role="img" aria-label="coverage: {{current}}%">
+    <title>coverage: {{current}}%</title>
+    <linearGradient id="s" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <clipPath id="r">
+        <rect width="{{width}}" height="20" rx="3" fill="#fff"/>
+    </clipPath>
+    <g clip-path="url(#r)">
+        <rect width="61" height="20" fill="#555"/>
+        <rect x="61" width="{{width - 61}}" height="20" fill="{{color}}"/>
+        <rect width="{{width}}" height="20" fill="url(#s)"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+        <text aria-hidden="true" x="315" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="510">coverage</text>
+        <text x="315" y="140" transform="scale(.1)" fill="#fff" textLength="510">coverage</text>
+        <text aria-hidden="true" x="{{position}}" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="{{text_length}}">{{current}}%</text>
+        <text x="{{position}}" y="140" transform="scale(.1)" fill="#fff" textLength="{{text_length}}">{{current}}%</text>
+    </g>
+    <script xmlns=""/>
+</svg>

--- a/src/templates/badges/flat_square.svg
+++ b/src/templates/badges/flat_square.svg
@@ -1,0 +1,34 @@
+{# Original badge design by https://github.com/badges/shields under the CC0-1.0 license. #}
+{%- if current >= 100 -%}
+    {%- set width = 104 -%}
+    {%- set position = 815 -%}
+    {%- set text_length = 330 -%}
+{%- elif current >= 10 -%}
+    {%- set width = 96 -%}
+    {%- set position = 775 -%}
+    {%- set text_length = 250 -%}
+{%- else -%}
+    {%- set width = 90 -%}
+    {%- set position = 745 -%}
+    {%- set text_length = 190 -%}
+{%- endif -%}
+{%- if current >= hi_limit -%}
+    {%- set color = "#97ca00" -%}
+{%- elif current >= med_limit -%}
+    {%- set color = "#dfb317" -%}
+{%- else -%}
+    {%- set color = "#e05d44" -%}
+{%- endif -%}
+<svg xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink" width="{{width}}" height="20" role="img" aria-label="coverage: {{current}}%">
+    <title>coverage: {{current}}%</title>
+    <g shape-rendering="crispEdges">
+        <rect width="61" height="20" fill="#555"/>
+        <rect x="61" width="{{width - 61}}" height="20" fill="{{color}}"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+        <text x="315" y="140" transform="scale(.1)" fill="#fff" textLength="510">coverage</text>
+        <text x="{{position}}" y="140" transform="scale(.1)" fill="#fff" textLength="{{text_length}}">{{current}}%</text>
+    </g>
+    <script xmlns=""/>
+</svg>

--- a/src/templates/badges/for_the_badge.svg
+++ b/src/templates/badges/for_the_badge.svg
@@ -1,0 +1,34 @@
+{# Original badge design by https://github.com/badges/shields under the CC0-1.0 license. #}
+{%- if current >= 100 -%}
+    {%- set width = 152 -%}
+    {%- set position = 1215 -%}
+    {%- set text_length = 370 -%}
+{%- elif current >= 10 -%}
+    {%- set width = 142.5 -%}
+    {%- set position = 1167.5 -%}
+    {%- set text_length = 275 -%}
+{%- else -%}
+    {%- set width = 133 -%}
+    {%- set position = 1120 -%}
+    {%- set text_length = 180 -%}
+{%- endif -%}
+{%- if current >= hi_limit -%}
+    {%- set color = "#97ca00" -%}
+{%- elif current >= med_limit -%}
+    {%- set color = "#dfb317" -%}
+{%- else -%}
+    {%- set color = "#e05d44" -%}
+{%- endif -%}
+<svg xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink" width="{{width}}" height="28" role="img" aria-label="COVERAGE: {{current}}%">
+    <title>COVERAGE: {{current}}%</title>
+    <g shape-rendering="crispEdges">
+        <rect width="91" height="28" fill="#555"/>
+        <rect x="91" width="{{width - 91}}" height="28" fill="{{color}}"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="100">
+        <text fill="#fff" x="455" y="175" transform="scale(.1)" textLength="670">COVERAGE</text>
+        <text fill="#fff" x="{{position}}" y="175" font-weight="bold" transform="scale(.1)" textLength="{{text_length}}">{{current}}%</text>
+    </g>
+    <script xmlns=""/>
+</svg>

--- a/src/templates/badges/plastic.svg
+++ b/src/templates/badges/plastic.svg
@@ -1,0 +1,46 @@
+{# Original badge design by https://github.com/badges/shields under the CC0-1.0 license. #}
+{%- if current >= 100 -%}
+    {%- set width = 104 -%}
+    {%- set position = 815 -%}
+    {%- set text_length = 330 -%}
+{%- elif current >= 10 -%}
+    {%- set width = 96 -%}
+    {%- set position = 775 -%}
+    {%- set text_length = 250 -%}
+{%- else -%}
+    {%- set width = 90 -%}
+    {%- set position = 745 -%}
+    {%- set text_length = 190 -%}
+{%- endif -%}
+{%- if current >= hi_limit -%}
+    {%- set color = "#97ca00" -%}
+{%- elif current >= med_limit -%}
+    {%- set color = "#dfb317" -%}
+{%- else -%}
+    {%- set color = "#e05d44" -%}
+{%- endif -%}
+<svg xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink" width="{{width}}" height="18" role="img" aria-label="coverage: {{current}}%">
+    <title>coverage: {{current}}%</title>
+    <linearGradient id="s" x2="0" y2="100%">
+        <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
+        <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
+        <stop offset=".9" stop-color="#000" stop-opacity=".3"/>
+        <stop offset="1" stop-color="#000" stop-opacity=".5"/>
+    </linearGradient>
+    <clipPath id="r">
+        <rect width="{{width}}" height="18" rx="4" fill="#fff"/>
+    </clipPath>
+    <g clip-path="url(#r)">
+        <rect width="61" height="18" fill="#555"/>
+        <rect x="61" width="{{width - 61}}" height="18" fill="{{color}}"/>
+        <rect width="{{width}}" height="18" fill="url(#s)"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+        <text aria-hidden="true" x="315" y="140" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="510">coverage</text>
+        <text x="315" y="130" transform="scale(.1)" fill="#fff" textLength="510">coverage</text>
+        <text aria-hidden="true" x="{{position}}" y="140" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="{{text_length}}">{{current}}%</text>
+        <text x="{{position}}" y="130" transform="scale(.1)" fill="#fff" textLength="{{text_length}}">{{current}}%</text>
+    </g>
+    <script xmlns=""/>
+</svg>

--- a/src/templates/badges/social.svg
+++ b/src/templates/badges/social.svg
@@ -1,0 +1,41 @@
+{# Original badge design by https://github.com/badges/shields under the CC0-1.0 license. #}
+{%- if current >= 100 -%}
+    {%- set width = 105 -%}
+    {%- set position = 855 -%}
+    {%- set text_length = 290 -%}
+{%- elif current >= 10 -%}
+    {%- set width = 99 -%}
+    {%- set position = 825 -%}
+    {%- set text_length = 230 -%}
+{%- else -%}
+    {%- set width = 93 -%}
+    {%- set position = 795 -%}
+    {%- set text_length = 170 -%}
+{%- endif -%}
+<svg xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink" width="{{width}}" height="20" role="img" aria-label="Coverage: {{current}}%">
+    <title>Coverage: {{current}}%</title>
+    <style>a:hover #llink{fill:url(#b);stroke:#ccc}a:hover #rlink{fill:#4183c4}</style>
+    <linearGradient id="a" x2="0" y2="100%">
+        <stop offset="0" stop-color="#fcfcfc" stop-opacity="0"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#ccc" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <g stroke="#d5d5d5">
+        <rect stroke="none" fill="#fcfcfc" x="0.5" y="0.5" width="61" height="19" rx="2"/>
+        <rect x="67.5" y="0.5" width="{{width - 68}}" height="19" rx="2" fill="#fafafa"/>
+        <rect x="67" y="7.5" width="0.5" height="5" stroke="#fafafa"/>
+        <path d="M67.5 6.5 l-3 3v1 l3 3" stroke="d5d5d5" fill="#fafafa"/>
+    </g>
+    <g aria-hidden="true" fill="#333" text-anchor="middle" font-family="Helvetica Neue,Helvetica,Arial,sans-serif" text-rendering="geometricPrecision" font-weight="700" font-size="110px" line-height="14px">
+        <rect id="llink" stroke="#d5d5d5" fill="url(#a)" x=".5" y=".5" width="61" height="19" rx="2"/>
+        <text aria-hidden="true" x="305" y="150" fill="#fff" transform="scale(.1)" textLength="510">Coverage</text>
+        <text x="305" y="140" transform="scale(.1)" textLength="510">Coverage</text>
+        <text aria-hidden="true" x="{{position}}" y="150" fill="#fff" transform="scale(.1)" textLength="{{text_length}}">{{current}}%</text>
+        <text id="rlink" x="{{position}}" y="140" transform="scale(.1)" textLength="{{text_length}}">{{current}}%</text>
+    </g>
+    <script xmlns=""/>
+</svg>


### PR DESCRIPTION
This adds generation of SVG badges and a `coverage.json` file that can be used with shields.io/endpoint to generate badges dynamically.

The motivation is pretty much explained in #616 and allows to put a coverage badge in the project readme when statically hosting the HTML report instead of relying on services lie codecov or coveralls.

I took the badge rendering from [shields.io](https://github.com/badges/shields) and as they're licensed under **CC0**, it _should_ (!) be fine to use.