### PR TITLE
Fix all reported clippy warnings

### DIFF
--- a/src/cobertura.rs
+++ b/src/cobertura.rs
@@ -197,10 +197,7 @@ impl Line {
     }
 
     fn covered(&self) -> bool {
-        match self {
-            Line::Plain { hits, .. } | Line::Branch { hits, .. } if *hits > 0 => true,
-            _ => false,
-        }
+        matches!(self, Line::Plain { hits, .. } | Line::Branch { hits, .. } if *hits > 0)
     }
 }
 
@@ -559,9 +556,9 @@ mod tests {
     extern crate tempfile;
     use super::*;
     use crate::{CovResult, Function};
-    use std::fs::File;
     use std::io::Read;
     use std::{collections::BTreeMap, path::PathBuf};
+    use std::{fs::File, path::Path};
 
     enum Result {
         Main,
@@ -693,9 +690,9 @@ mod tests {
         }
     }
 
-    fn read_file(path: &PathBuf) -> String {
+    fn read_file(path: &Path) -> String {
         let mut f =
-            File::open(path).expect(format!("{:?} file not found", path.file_name()).as_str());
+            File::open(path).unwrap_or_else(|_| panic!("{:?} file not found", path.file_name()));
         let mut s = String::new();
         f.read_to_string(&mut s).unwrap();
         s

--- a/src/covdir.rs
+++ b/src/covdir.rs
@@ -95,14 +95,14 @@ impl CDDirStats {
         self.stats.set_percent();
     }
 
-    pub fn to_json(&mut self) -> serde_json::Value {
+    pub fn into_json(self) -> serde_json::Value {
         let mut children = Map::new();
-        for file in self.files.drain(..) {
+        for file in self.files {
             children.insert(file.name.clone(), file.to_json());
         }
-        for dir in self.dirs.drain(..) {
-            let mut dir = dir.borrow_mut();
-            children.insert(dir.name.clone(), dir.to_json());
+        for dir in self.dirs {
+            let dir = dir.take();
+            children.insert(dir.name.clone(), dir.into_json());
         }
         json!({
             "name": self.name,

--- a/src/defs.rs
+++ b/src/defs.rs
@@ -145,3 +145,8 @@ impl<'a> Serialize for StringOrRef<'a> {
         }
     }
 }
+
+pub struct JacocoReport {
+    pub lines: BTreeMap<u32, u64>,
+    pub branches: BTreeMap<u32, Vec<bool>>,
+}

--- a/src/defs.rs
+++ b/src/defs.rs
@@ -22,12 +22,11 @@ pub struct CovResult {
 }
 
 #[derive(Debug, PartialEq, Copy, Clone)]
-#[allow(non_camel_case_types)]
 pub enum ItemFormat {
-    GCNO,
-    PROFRAW,
-    INFO,
-    JACOCO_XML,
+    Gcno,
+    Profraw,
+    Info,
+    JacocoXml,
 }
 
 #[derive(Debug)]
@@ -76,7 +75,7 @@ pub struct CDFileStats {
     pub coverage: Vec<i64>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct CDDirStats {
     pub name: String,
     pub files: Vec<CDFileStats>,

--- a/src/file_filter.rs
+++ b/src/file_filter.rs
@@ -1,5 +1,5 @@
 use regex::Regex;
-use std::path::PathBuf;
+use std::path::Path;
 
 pub enum FilterType {
     Line(u32),
@@ -36,7 +36,7 @@ impl FileFilter {
         }
     }
 
-    pub fn create(&self, file: &PathBuf) -> Vec<FilterType> {
+    pub fn create(&self, file: &Path) -> Vec<FilterType> {
         if self.excl_line.is_none()
             && self.excl_start.is_none()
             && self.excl_br_line.is_none()
@@ -63,11 +63,7 @@ impl FileFilter {
 
                 // The file is split on \n, which may result in a trailing \r
                 // on Windows. Remove it.
-                let line = if line.ends_with('\r') {
-                    &line[..(line.len() - 1)]
-                } else {
-                    line
-                };
+                let line = line.strip_suffix('\r').unwrap_or(line);
 
                 // End a branch ignore region. Region endings are exclusive.
                 if ignore_br

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -16,7 +16,7 @@ pub fn is_covered(result: &CovResult) -> bool {
     let any_function_covered = result
         .functions
         .iter()
-        .any(|(name, ref function)| function.executed && name != "top-level");
+        .any(|(name, function)| function.executed && name != "top-level");
     result.functions.len() <= 1 || any_function_covered
 }
 

--- a/src/gcov.rs
+++ b/src/gcov.rs
@@ -1,7 +1,7 @@
 use semver::Version;
 use std::env;
 use std::fmt;
-use std::path::PathBuf;
+use std::path::Path;
 use std::process::Command;
 
 #[derive(Debug)]
@@ -32,9 +32,9 @@ fn get_gcov() -> String {
 }
 
 pub fn run_gcov(
-    gcno_path: &PathBuf,
+    gcno_path: &Path,
     branch_enabled: bool,
-    working_dir: &PathBuf,
+    working_dir: &Path,
 ) -> Result<(), GcovError> {
     let mut command = Command::new(&get_gcov());
     let command = if branch_enabled {

--- a/src/html.rs
+++ b/src/html.rs
@@ -251,7 +251,7 @@ pub fn gen_index(
     }
 
     for (dir_name, dir_stats) in global.dirs.iter() {
-        gen_dir_index(&tera, dir_name, dir_stats, &conf, output, branch_enabled);
+        gen_dir_index(tera, dir_name, dir_stats, conf, output, branch_enabled);
     }
 }
 
@@ -314,10 +314,10 @@ fn gen_html(
     };
     let f = BufReader::new(f);
 
-    let stats = get_stats(&result);
-    get_dirs_result(global, &rel_path, &stats);
+    let stats = get_stats(result);
+    get_dirs_result(global, rel_path, &stats);
 
-    let output_file = output.join(add_html_ext(&rel_path));
+    let output_file = output.join(add_html_ext(rel_path));
     create_parent(&output_file);
     let mut output = match File::create(&output_file) {
         Err(_) => {
@@ -326,7 +326,7 @@ fn gen_html(
         }
         Ok(f) => f,
     };
-    let base_url = get_base(&rel_path);
+    let base_url = get_base(rel_path);
     let filename = rel_path.file_name().unwrap().to_str().unwrap();
     let parent = rel_path.parent().unwrap().to_str().unwrap().to_string();
     let mut index_url = base_url;

--- a/src/html.rs
+++ b/src/html.rs
@@ -35,7 +35,7 @@ pub struct Config {
     date: DateTime<Utc>,
 }
 
-static BULMA_VERSION: &'static str = "0.9.1";
+static BULMA_VERSION: &str = "0.9.1";
 
 pub fn get_config() -> (Tera, Config) {
     let conf = Config {
@@ -113,14 +113,14 @@ impl tera::Filter for Config {
     }
 }
 
-fn create_parent(path: &PathBuf) {
+fn create_parent(path: &Path) {
     let dest_parent = path.parent().unwrap();
     if !dest_parent.exists() && fs::create_dir_all(dest_parent).is_err() {
         panic!("Cannot create parent directory: {:?}", dest_parent);
     }
 }
 
-fn add_html_ext(path: &PathBuf) -> PathBuf {
+fn add_html_ext(path: &Path) -> PathBuf {
     if let Some(ext) = path.extension() {
         let mut ext = ext.to_str().unwrap().to_owned();
         ext.push_str(".html");
@@ -176,12 +176,12 @@ fn percent(args: &HashMap<String, Value>) -> tera::Result<Value> {
     }
 }
 
-fn get_base(rel_path: &PathBuf) -> String {
+fn get_base(rel_path: &Path) -> String {
     let count = rel_path.components().count() - 1 /* -1 for the file itself */;
-    "../".repeat(count).to_string()
+    "../".repeat(count)
 }
 
-fn get_dirs_result(global: Arc<Mutex<HtmlGlobalStats>>, rel_path: &PathBuf, stats: &HtmlStats) {
+fn get_dirs_result(global: Arc<Mutex<HtmlGlobalStats>>, rel_path: &Path, stats: &HtmlStats) {
     let parent = rel_path.parent().unwrap().to_str().unwrap().to_string();
     let file_name = rel_path.file_name().unwrap().to_str().unwrap().to_string();
     let fs = HtmlFileStats {
@@ -220,7 +220,7 @@ pub fn gen_index(
     tera: &Tera,
     global: &HtmlGlobalStats,
     conf: &Config,
-    output: &PathBuf,
+    output: &Path,
     branch_enabled: bool,
 ) {
     let output_file = output.join("index.html");
@@ -260,10 +260,10 @@ pub fn gen_dir_index(
     dir_name: &str,
     dir_stats: &HtmlDirStats,
     conf: &Config,
-    output: &PathBuf,
+    output: &Path,
     branch_enabled: bool,
 ) {
-    let index = PathBuf::from(dir_name).join("index.html");
+    let index = Path::new(dir_name).join("index.html");
     let output_file = output.join(&index);
     create_parent(&output_file);
     let mut output = match File::create(&output_file) {
@@ -293,11 +293,11 @@ pub fn gen_dir_index(
 
 fn gen_html(
     tera: &Tera,
-    path: PathBuf,
+    path: &Path,
     result: &CovResult,
     conf: &Config,
-    output: &PathBuf,
-    rel_path: &PathBuf,
+    output: &Path,
+    rel_path: &Path,
     global: Arc<Mutex<HtmlGlobalStats>>,
     branch_enabled: bool,
 ) {
@@ -329,7 +329,7 @@ fn gen_html(
     let base_url = get_base(&rel_path);
     let filename = rel_path.file_name().unwrap().to_str().unwrap();
     let parent = rel_path.parent().unwrap().to_str().unwrap().to_string();
-    let mut index_url = base_url.clone();
+    let mut index_url = base_url;
     index_url.push_str("index.html");
 
     let mut ctx = make_context();
@@ -374,7 +374,7 @@ pub fn consumer_html(
     tera: &Tera,
     receiver: HtmlJobReceiver,
     global: Arc<Mutex<HtmlGlobalStats>>,
-    output: PathBuf,
+    output: &Path,
     conf: Config,
     branch_enabled: bool,
 ) {
@@ -385,10 +385,10 @@ pub fn consumer_html(
         let job = job.unwrap();
         gen_html(
             tera,
-            job.abs_path,
+            &job.abs_path,
             &job.result,
             &conf,
-            &output,
+            output,
             &job.rel_path,
             global.clone(),
             branch_enabled,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 #![recursion_limit = "1024"]
+#![allow(clippy::too_many_arguments)]
+
 extern crate cargo_binutils;
 extern crate chrono;
 extern crate crossbeam;
@@ -57,10 +59,12 @@ mod file_filter;
 pub use crate::file_filter::*;
 
 use log::{error, warn};
-use std::collections::{btree_map, hash_map};
 use std::fs;
 use std::io::{BufReader, Cursor};
-use std::path::PathBuf;
+use std::{
+    collections::{btree_map, hash_map},
+    path::Path,
+};
 use walkdir::WalkDir;
 
 // Merge results, without caring about duplicate lines (they will be removed at the end).
@@ -109,13 +113,13 @@ pub fn merge_results(result: &mut CovResult, result2: CovResult) -> bool {
         };
     }
 
-    return warn_overflow;
+    warn_overflow
 }
 
 fn add_results(
     mut results: Vec<(String, CovResult)>,
     result_map: &SyncCovResultMap,
-    source_dir: &Option<PathBuf>,
+    source_dir: Option<&Path>,
 ) {
     let mut map = result_map.lock().unwrap();
     let mut warn_overflow = false;
@@ -150,7 +154,7 @@ fn rename_single_files(results: &mut Vec<(String, CovResult)>, stem: &str) {
     // sometimes the gcno just contains foo.c
     // so in such case (with option --guess-directory-when-missing)
     // we guess the filename in using the buffer stem
-    if let Some(parent) = PathBuf::from(stem).parent() {
+    if let Some(parent) = Path::new(stem).parent() {
         for (file, _) in results.iter_mut() {
             if has_no_parent(file) {
                 *file = parent.join(&file).to_str().unwrap().to_string();
@@ -181,13 +185,13 @@ macro_rules! try_parse {
 }
 
 pub fn consumer(
-    working_dir: &PathBuf,
-    source_dir: &Option<PathBuf>,
+    working_dir: &Path,
+    source_dir: Option<&Path>,
     result_map: &SyncCovResultMap,
     receiver: JobReceiver,
     branch_enabled: bool,
     guess_directory: bool,
-    binary_path: &Option<PathBuf>,
+    binary_path: Option<&Path>,
 ) {
     let mut gcov_type = GcovType::Unknown;
 
@@ -197,7 +201,7 @@ pub fn consumer(
         }
         let work_item = work_item.unwrap();
         let new_results = match work_item.format {
-            ItemFormat::GCNO => {
+            ItemFormat::Gcno => {
                 match work_item.item {
                     ItemType::Path((stem, gcno_path)) => {
                         // GCC
@@ -259,7 +263,7 @@ pub fn consumer(
                     }
                     ItemType::Buffers(buffers) => {
                         // LLVM
-                        match GCNO::compute(
+                        match Gcno::compute(
                             &buffers.stem,
                             buffers.gcno_buf,
                             buffers.gcda_buf,
@@ -288,7 +292,7 @@ pub fn consumer(
                     }
                 }
             }
-            ItemFormat::PROFRAW => {
+            ItemFormat::Profraw => {
                 if binary_path.is_none() {
                     error!("The path to the compiled binary must be given as an argument when source-based coverage is used");
                     continue;
@@ -322,9 +326,9 @@ pub fn consumer(
                     continue;
                 }
             }
-            ItemFormat::INFO | ItemFormat::JACOCO_XML => {
+            ItemFormat::Info | ItemFormat::JacocoXml => {
                 if let ItemType::Content(content) = work_item.item {
-                    if work_item.format == ItemFormat::INFO {
+                    if work_item.format == ItemFormat::Info {
                         try_parse!(parse_lcov(content, branch_enabled), work_item.name)
                     } else {
                         let buffer = BufReader::new(Cursor::new(content));
@@ -433,10 +437,10 @@ mod tests {
         assert!(result.functions.contains_key("f2"));
         let mut func = result.functions.get("f1").unwrap();
         assert_eq!(func.start, 1);
-        assert_eq!(func.executed, false);
+        assert!(!func.executed);
         func = result.functions.get("f2").unwrap();
         assert_eq!(func.start, 2);
-        assert_eq!(func.executed, true);
+        assert!(func.executed);
     }
 
     #[test]
@@ -452,14 +456,14 @@ mod tests {
         add_results(
             results,
             &result_map,
-            &Some(PathBuf::from("./test/relative_path")),
+            Some(Path::new("./test/relative_path")),
         );
         let result_map = Arc::try_unwrap(result_map).unwrap().into_inner().unwrap();
 
         assert!(result_map.len() == 1);
 
         let cpp_file =
-            canonicalize_path(PathBuf::from("./test/relative_path/foo/bar/oof.cpp")).unwrap();
+            canonicalize_path(Path::new("./test/relative_path/foo/bar/oof.cpp")).unwrap();
         let cpp_file = cpp_file.to_str().unwrap();
         let cov_result = result_map.get(cpp_file).unwrap();
 
@@ -483,7 +487,7 @@ mod tests {
         let result_map: Arc<SyncCovResultMap> = Arc::new(Mutex::new(
             FxHashMap::with_capacity_and_hasher(3, Default::default()),
         ));
-        add_results(results, &result_map, &None);
+        add_results(results, &result_map, None);
         let result_map = Arc::try_unwrap(result_map).unwrap().into_inner().unwrap();
 
         assert!(result_map.len() == 3);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,9 +243,9 @@ pub fn consumer(
 
                                 new_results.append(&mut try_parse!(
                                     if gcov_path.extension().unwrap() == "gz" {
-                                        parse_gcov_gz(&gcov_path)
+                                        parse_gcov_gz(gcov_path)
                                     } else {
-                                        parse_gcov(&gcov_path)
+                                        parse_gcov(gcov_path)
                                     },
                                     work_item.name
                                 ));

--- a/src/llvm_tools.rs
+++ b/src/llvm_tools.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 
 use walkdir::WalkDir;
 
-pub fn run(cmd: &Path, args: &[&OsStr]) -> Result<Vec<u8>, String> {
+pub fn run(cmd: impl AsRef<OsStr>, args: &[&OsStr]) -> Result<Vec<u8>, String> {
     let mut command = Command::new(cmd);
     command.args(args);
     let output = match command.output() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -259,7 +259,7 @@ fn main() {
     let source_dir = matches.value_of("source_dir").unwrap_or("");
     let prefix_dir = matches.value_of("prefix_dir").unwrap_or("");
     let ignore_not_existing = matches.is_present("ignore_not_existing");
-    let mut to_ignore_dirs: Vec<_> = if let Some(to_ignore_dirs) = matches.values_of("ignore_dir") {
+    let to_ignore_dirs = if let Some(to_ignore_dirs) = matches.values_of("ignore_dir") {
         to_ignore_dirs.collect()
     } else {
         Vec::new()
@@ -481,7 +481,7 @@ fn main() {
         source_root.as_deref(),
         prefix_dir.as_deref(),
         ignore_not_existing,
-        &mut to_ignore_dirs,
+        &to_ignore_dirs,
         &to_keep_dirs,
         filter_option,
         file_filter,

--- a/src/main.rs
+++ b/src/main.rs
@@ -253,11 +253,7 @@ fn main() {
 
     let paths: Vec<_> = matches.values_of("paths").unwrap().collect();
     let paths: Vec<String> = paths.iter().map(|s| s.to_string()).collect();
-    let binary_path = if let Some(binary_path) = matches.value_of("binary_path") {
-        Some(PathBuf::from(binary_path))
-    } else {
-        None
-    };
+    let binary_path = matches.value_of("binary_path").map(PathBuf::from);
     let output_type = matches.value_of("output_type").unwrap();
     let output_path = matches.value_of("output_path");
     let source_dir = matches.value_of("source_dir").unwrap_or("");
@@ -270,7 +266,7 @@ fn main() {
     };
     let to_keep_dirs: Vec<_> = matches
         .values_of("keep_dir")
-        .map_or_else(|| Vec::new(), |dirs| dirs.collect());
+        .map_or_else(Vec::new, |dirs| dirs.collect());
     let path_mapping_file = matches.value_of("path_mapping").unwrap_or("");
     let branch_enabled = matches.is_present("branch");
     let filter_option = if let Some(filter) = matches.value_of("filter") {
@@ -326,22 +322,22 @@ fn main() {
 
     let excl_line = matches
         .value_of("excl-line")
-        .and_then(|f| Some(regex::Regex::new(f).expect("invalid regex for excl-line.")));
+        .map(|f| regex::Regex::new(f).expect("invalid regex for excl-line."));
     let excl_start = matches
         .value_of("excl-start")
-        .and_then(|f| Some(regex::Regex::new(f).expect("invalid regex for excl-start.")));
+        .map(|f| regex::Regex::new(f).expect("invalid regex for excl-start."));
     let excl_stop = matches
         .value_of("excl-stop")
-        .and_then(|f| Some(regex::Regex::new(f).expect("invalid regex for excl-stop.")));
+        .map(|f| regex::Regex::new(f).expect("invalid regex for excl-stop."));
     let excl_br_line = matches
         .value_of("excl-br-line")
-        .and_then(|f| Some(regex::Regex::new(f).expect("invalid regex for excl-br-line.")));
+        .map(|f| regex::Regex::new(f).expect("invalid regex for excl-br-line."));
     let excl_br_start = matches
         .value_of("excl-br-start")
-        .and_then(|f| Some(regex::Regex::new(f).expect("invalid regex for excl-br-start.")));
+        .map(|f| regex::Regex::new(f).expect("invalid regex for excl-br-start."));
     let excl_br_stop = matches
         .value_of("excl-br-stop")
-        .and_then(|f| Some(regex::Regex::new(f).expect("invalid regex for excl-br-stop.")));
+        .map(|f| regex::Regex::new(f).expect("invalid regex for excl-br-stop."));
     let file_filter = FileFilter::new(
         excl_line,
         excl_start,
@@ -365,7 +361,7 @@ fn main() {
             panic_info
                 .payload()
                 .downcast_ref::<&str>()
-                .map(|s| *s)
+                .copied()
                 .unwrap_or("<cause unknown>")
         });
         error!("A panic occurred at {}:{}: {}", filename, line, cause);
@@ -378,13 +374,13 @@ fn main() {
         .expect("Number of threads should be a number");
     let guess_directory = matches.is_present("guess_directory");
 
-    let source_root = if source_dir != "" {
+    let source_root = if !source_dir.is_empty() {
         Some(canonicalize_path(&source_dir).expect("Source directory does not exist."))
     } else {
         None
     };
 
-    let prefix_dir = if prefix_dir == "" {
+    let prefix_dir = if prefix_dir.is_empty() {
         source_root.clone()
     } else {
         Some(PathBuf::from(prefix_dir))
@@ -418,13 +414,13 @@ fn main() {
                 );
 
                 let mut path_mapping = path_mapping.lock().unwrap();
-                *path_mapping = if path_mapping_file != "" {
+                *path_mapping = if !path_mapping_file.is_empty() {
                     let file = File::open(path_mapping_file).unwrap();
                     Some(serde_json::from_reader(file).unwrap())
-                } else if let Some(producer_path_mapping_buf) = producer_path_mapping_buf {
-                    Some(serde_json::from_slice(&producer_path_mapping_buf).unwrap())
                 } else {
-                    None
+                    producer_path_mapping_buf.map(|producer_path_mapping_buf| {
+                        serde_json::from_slice(&producer_path_mapping_buf).unwrap()
+                    })
                 };
             })
             .unwrap()
@@ -445,12 +441,12 @@ fn main() {
                 fs::create_dir(&working_dir).expect("Failed to create working directory");
                 consumer(
                     &working_dir,
-                    &source_root,
+                    source_root.as_deref(),
                     &result_map,
                     receiver,
                     branch_enabled,
                     guess_directory,
-                    &binary_path,
+                    binary_path.as_deref(),
                 );
             })
             .unwrap();
@@ -458,7 +454,7 @@ fn main() {
         parsers.push(t);
     }
 
-    if let Err(_) = producer.join() {
+    if producer.join().is_err() {
         process::exit(1);
     }
 
@@ -468,7 +464,7 @@ fn main() {
     }
 
     for parser in parsers {
-        if let Err(_) = parser.join() {
+        if parser.join().is_err() {
             process::exit(1);
         }
     }
@@ -482,8 +478,8 @@ fn main() {
     let iterator = rewrite_paths(
         result_map,
         path_mapping,
-        source_root,
-        prefix_dir,
+        source_root.as_deref(),
+        prefix_dir.as_deref(),
         ignore_not_existing,
         &mut to_ignore_dirs,
         &to_keep_dirs,
@@ -491,12 +487,10 @@ fn main() {
         file_filter,
     );
 
-    if output_type == "ade" {
-        output_activedata_etl(iterator, output_path, demangle);
-    } else if output_type == "lcov" {
-        output_lcov(iterator, output_path, demangle);
-    } else if output_type == "coveralls" {
-        output_coveralls(
+    match output_type {
+        "ade" => output_activedata_etl(iterator, output_path, demangle),
+        "lcov" => output_lcov(iterator, output_path, demangle),
+        "coveralls" => output_coveralls(
             iterator,
             repo_token,
             service_name,
@@ -509,9 +503,8 @@ fn main() {
             vcs_branch,
             is_parallel,
             demangle,
-        );
-    } else if output_type == "coveralls+" {
-        output_coveralls(
+        ),
+        "coveralls+" => output_coveralls(
             iterator,
             repo_token,
             service_name,
@@ -524,16 +517,11 @@ fn main() {
             vcs_branch,
             is_parallel,
             demangle,
-        );
-    } else if output_type == "files" {
-        output_files(iterator, output_path);
-    } else if output_type == "covdir" {
-        output_covdir(iterator, output_path);
-    } else if output_type == "html" {
-        output_html(iterator, output_path, num_threads, branch_enabled);
-    } else if output_type == "cobertura" {
-        output_cobertura(iterator, output_path, demangle);
-    } else {
-        assert!(false, "{} is not a supported output type", output_type);
-    }
+        ),
+        "files" => output_files(iterator, output_path),
+        "covdir" => output_covdir(iterator, output_path),
+        "html" => output_html(iterator, output_path, num_threads, branch_enabled),
+        "cobertura" => output_cobertura(iterator, output_path, demangle),
+        _ => panic!("{} is not a supported output type", output_type),
+    };
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -96,7 +96,7 @@ pub fn output_activedata_etl(results: CovResultIter, output_file: Option<&str>, 
         for function in result.functions.values() {
             start_indexes.push(function.start);
         }
-        start_indexes.sort();
+        start_indexes.sort_unstable();
 
         for (name, function) in &result.functions {
             // println!("{} {} {}", name, function.executed, function.start);
@@ -227,10 +227,10 @@ pub fn output_covdir(results: CovResultIter, output_file: Option<&str>) {
         ));
     }
 
-    let mut global = global.borrow_mut();
+    let mut global = global.take();
     global.set_stats();
 
-    serde_json::to_writer(&mut writer, &global.to_json()).unwrap();
+    serde_json::to_writer(&mut writer, &global.into_json()).unwrap();
 }
 
 pub fn output_lcov(results: CovResultIter, output_file: Option<&str>, demangle: bool) {
@@ -336,7 +336,7 @@ where
         .and_then(|child| child.wait_with_output())
         .ok() // Discard the error type -- we won't handle it anyway
         .and_then(|output| String::from_utf8(output.stdout).ok())
-        .unwrap_or_else(|| String::new())
+        .unwrap_or_default()
 }
 
 /// Returns a JSON object describing the given commit. Coveralls uses that to display commit info.
@@ -387,9 +387,8 @@ fn get_coveralls_git_info(commit_sha: &str, vcs_branch: &str) -> Value {
         for line in output.lines() {
             if line.ends_with(" (fetch)") {
                 let mut fields = line.split_whitespace();
-                match (fields.next(), fields.next()) {
-                    (Some(name), Some(url)) => remotes.push(json!({"name": name, "url": url})),
-                    _ => (),
+                if let (Some(name), Some(url)) = (fields.next(), fields.next()) {
+                    remotes.push(json!({"name": name, "url": url}))
                 };
             }
         }
@@ -546,7 +545,7 @@ pub fn output_html(
         let t = thread::Builder::new()
             .name(format!("Consumer HTML {}", i))
             .spawn(move || {
-                html::consumer_html(&tera, receiver, stats, output, config, branch_enabled);
+                html::consumer_html(&tera, receiver, stats, &output, config, branch_enabled);
             })
             .unwrap();
 
@@ -586,14 +585,13 @@ pub fn output_html(
 
 #[cfg(test)]
 mod tests {
-
     extern crate tempfile;
     use super::*;
-    use std::collections::BTreeMap;
+    use std::{collections::BTreeMap, path::Path};
 
-    fn read_file(path: &PathBuf) -> String {
+    fn read_file(path: &Path) -> String {
         let mut f =
-            File::open(path).expect(format!("{:?} file not found", path.file_name()).as_str());
+            File::open(path).unwrap_or_else(|_| panic!("{:?} file not found", path.file_name()));
         let mut s = String::new();
         f.read_to_string(&mut s).unwrap();
         s

--- a/src/output.rs
+++ b/src/output.rs
@@ -274,7 +274,7 @@ pub fn output_lcov(results: CovResultIter, output_file: Option<&str>, demangle: 
         // branch coverage information
         let mut branch_count = 0;
         let mut branch_hit = 0;
-        for (line, ref taken) in &result.branches {
+        for (line, taken) in &result.branches {
             branch_count += taken.len();
             for (n, b_t) in taken.iter().enumerate() {
                 writeln!(
@@ -440,7 +440,7 @@ pub fn output_coveralls(
         }
 
         let mut branches = Vec::new();
-        for (line, ref taken) in &result.branches {
+        for (line, taken) in &result.branches {
             for (n, b_t) in taken.iter().enumerate() {
                 branches.push(*line);
                 branches.push(0);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -531,11 +531,6 @@ fn get_xml_attribute<R: BufRead>(
     )))
 }
 
-struct JacocoReport {
-    lines: BTreeMap<u32, u64>,
-    branches: BTreeMap<u32, Vec<bool>>,
-}
-
 fn parse_jacoco_report_sourcefile<T: BufRead>(
     parser: &mut Reader<T>,
     buf: &mut Vec<u8>,

--- a/src/path_rewriting.rs
+++ b/src/path_rewriting.rs
@@ -129,12 +129,12 @@ fn fixup_rel_path(source_dir: Option<&Path>, abs_path: &Path, rel_path: PathBuf)
 fn get_abs_path(source_dir: Option<&Path>, rel_path: PathBuf) -> Option<(PathBuf, PathBuf)> {
     let mut abs_path = if !rel_path.is_relative() {
         rel_path.to_owned()
-    } else if let Some(ref source_dir) = source_dir {
+    } else if let Some(source_dir) = source_dir {
         if !cfg!(windows) {
-            guess_abs_path(&source_dir, &rel_path)
+            guess_abs_path(source_dir, &rel_path)
         } else {
             guess_abs_path(
-                &source_dir,
+                source_dir,
                 &PathBuf::from(&rel_path.to_str().unwrap().replace("/", "\\")),
             )
         }
@@ -219,7 +219,7 @@ fn to_globset(dirs: &[&str]) -> GlobSet {
     let mut glob_builder = GlobSetBuilder::new();
 
     for dir in dirs {
-        glob_builder.add(Glob::new(&dir).unwrap());
+        glob_builder.add(Glob::new(dir).unwrap());
     }
 
     glob_builder.build().unwrap()
@@ -1651,17 +1651,17 @@ mod tests {
         for (_, _, result) in results {
             count += 1;
             for inc in [1, 2, 3, 5, 8, 9, 10, 11, 12, 13, 14, 15, 16].iter() {
-                assert!(result.lines.contains_key(&inc));
+                assert!(result.lines.contains_key(inc));
             }
             for inc in [4, 6, 7, 17, 18, 19, 20].iter() {
-                assert!(!result.lines.contains_key(&inc));
+                assert!(!result.lines.contains_key(inc));
             }
 
             for inc in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 15, 16, 17].iter() {
-                assert!(result.branches.contains_key(&inc));
+                assert!(result.branches.contains_key(inc));
             }
             for inc in [11, 13, 14, 18, 19, 20].iter() {
-                assert!(!result.branches.contains_key(&inc));
+                assert!(!result.branches.contains_key(inc));
             }
         }
         assert_eq!(count, 1);
@@ -1694,17 +1694,17 @@ mod tests {
         for (_, _, result) in results {
             count += 1;
             for inc in [1, 2, 3, 5, 8, 9, 10, 11, 12, 13, 14, 15, 16].iter() {
-                assert!(result.lines.contains_key(&inc));
+                assert!(result.lines.contains_key(inc));
             }
             for inc in [4, 6, 7, 17, 18, 19, 20].iter() {
-                assert!(!result.lines.contains_key(&inc));
+                assert!(!result.lines.contains_key(inc));
             }
 
             for inc in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 15, 16, 17].iter() {
-                assert!(result.branches.contains_key(&inc));
+                assert!(result.branches.contains_key(inc));
             }
             for inc in [11, 13, 14, 18, 19, 20].iter() {
-                assert!(!result.branches.contains_key(&inc));
+                assert!(!result.branches.contains_key(inc));
             }
         }
         assert_eq!(count, 1);

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -32,12 +32,12 @@ pub struct GCNOStem {
 }
 
 #[cfg(not(windows))]
-fn clean_path(path: &PathBuf) -> String {
+fn clean_path(path: &Path) -> String {
     path.to_str().unwrap().to_string()
 }
 
 #[cfg(windows)]
-fn clean_path(path: &PathBuf) -> String {
+fn clean_path(path: &Path) -> String {
     path.to_str().unwrap().to_string().replace("\\", "/")
 }
 
@@ -52,16 +52,14 @@ impl Archive {
             let vec = map.get_mut(&filename).unwrap();
             vec.push(self);
         } else {
-            let mut vec = Vec::new();
-            vec.push(self);
-            map.insert(filename, vec);
+            map.insert(filename, vec![self]);
         }
     }
 
     fn handle_file<'a>(
         &'a self,
         file: Option<&mut impl Read>,
-        path: &PathBuf,
+        path: &Path,
         gcno_stem_archives: &RefCell<FxHashMap<GCNOStem, &'a Archive>>,
         gcda_stem_archives: &RefCell<FxHashMap<String, Vec<&'a Archive>>>,
         profraws: &RefCell<FxHashMap<String, Vec<&'a Archive>>>,
@@ -253,7 +251,7 @@ impl Archive {
                         Ok(mut f) => {
                             let mut buf = Vec::with_capacity(metadata.len() as usize + 1);
                             f.read_to_end(&mut buf)
-                                .expect(&format!("Failed to read file: {}.", name));
+                                .unwrap_or_else(|_| panic!("Failed to read file: {}.", name));
                             Some(buf)
                         }
                         Err(_) => None,
@@ -265,7 +263,7 @@ impl Archive {
         }
     }
 
-    pub fn extract(&self, name: &str, path: &PathBuf) -> bool {
+    pub fn extract(&self, name: &str, path: &Path) -> bool {
         let dest_parent = path.parent().unwrap();
         if !dest_parent.exists() {
             fs::create_dir_all(dest_parent).expect("Cannot create parent directory");
@@ -316,7 +314,7 @@ fn gcno_gcda_producer(
     let send_job = |item, name| {
         sender
             .send(Some(WorkItem {
-                format: ItemFormat::GCNO,
+                format: ItemFormat::Gcno,
                 item,
                 name,
             }))
@@ -402,7 +400,7 @@ fn profraw_producer(
     profraws: &FxHashMap<String, Vec<&Archive>>,
     sender: &JobSender,
 ) {
-    if profraws.len() == 0 {
+    if profraws.is_empty() {
         return;
     }
 
@@ -435,7 +433,7 @@ fn profraw_producer(
 
     sender
         .send(Some(WorkItem {
-            format: ItemFormat::PROFRAW,
+            format: ItemFormat::Profraw,
             item: ItemType::Paths(profraw_paths),
             name: "profraws".to_string(),
         }))
@@ -560,8 +558,8 @@ pub fn producer(
         "No input files found"
     );
 
-    file_content_producer(&infos.into_inner(), sender, ItemFormat::INFO);
-    file_content_producer(&xmls.into_inner(), sender, ItemFormat::JACOCO_XML);
+    file_content_producer(&infos.into_inner(), sender, ItemFormat::Info);
+    file_content_producer(&xmls.into_inner(), sender, ItemFormat::JacocoXml);
     profraw_producer(tmp_dir, &profraws.into_inner(), sender);
     gcno_gcda_producer(
         tmp_dir,
@@ -647,7 +645,7 @@ mod tests {
 
             let p = directory.join(x.2);
             assert!(p.exists(), "{} doesn't exist", p.display());
-            if x.0 == ItemFormat::GCNO {
+            if x.0 == ItemFormat::Gcno {
                 let gcda =
                     p.with_file_name(format!("{}.gcda", p.file_stem().unwrap().to_str().unwrap()));
                 if x.3 {
@@ -668,96 +666,96 @@ mod tests {
         let mapping = producer(&tmp_path, &["test".to_string()], &sender, false, false);
 
         let expected = vec![
-            (ItemFormat::GCNO, true, "Platform_1.gcno", true),
+            (ItemFormat::Gcno, true, "Platform_1.gcno", true),
             (
-                ItemFormat::GCNO,
+                ItemFormat::Gcno,
                 true,
                 "sub2/RootAccessibleWrap_1.gcno",
                 true,
             ),
-            (ItemFormat::GCNO, true, "nsMaiInterfaceValue_1.gcno", true),
-            (ItemFormat::GCNO, true, "sub/prova2_1.gcno", true),
+            (ItemFormat::Gcno, true, "nsMaiInterfaceValue_1.gcno", true),
+            (ItemFormat::Gcno, true, "sub/prova2_1.gcno", true),
             (
-                ItemFormat::GCNO,
+                ItemFormat::Gcno,
                 true,
                 "nsMaiInterfaceDocument_1.gcno",
                 true,
             ),
             (
-                ItemFormat::GCNO,
+                ItemFormat::Gcno,
                 true,
                 "Unified_cpp_netwerk_base0_1.gcno",
                 true,
             ),
-            (ItemFormat::GCNO, true, "prova_1.gcno", true),
-            (ItemFormat::GCNO, true, "nsGnomeModule_1.gcno", true),
-            (ItemFormat::GCNO, true, "negative_counts_1.gcno", true),
-            (ItemFormat::GCNO, true, "64bit_count_1.gcno", true),
-            (ItemFormat::GCNO, true, "no_gcda/main_1.gcno", false),
-            (ItemFormat::GCNO, true, "only_one_gcda/main_1.gcno", true),
-            (ItemFormat::GCNO, true, "only_one_gcda/orphan_1.gcno", false),
+            (ItemFormat::Gcno, true, "prova_1.gcno", true),
+            (ItemFormat::Gcno, true, "nsGnomeModule_1.gcno", true),
+            (ItemFormat::Gcno, true, "negative_counts_1.gcno", true),
+            (ItemFormat::Gcno, true, "64bit_count_1.gcno", true),
+            (ItemFormat::Gcno, true, "no_gcda/main_1.gcno", false),
+            (ItemFormat::Gcno, true, "only_one_gcda/main_1.gcno", true),
+            (ItemFormat::Gcno, true, "only_one_gcda/orphan_1.gcno", false),
             (
-                ItemFormat::GCNO,
+                ItemFormat::Gcno,
                 true,
                 "gcno_symlink/gcda/main_1.gcno",
                 true,
             ),
             (
-                ItemFormat::GCNO,
+                ItemFormat::Gcno,
                 true,
                 "gcno_symlink/gcno/main_1.gcno",
                 false,
             ),
             (
-                ItemFormat::GCNO,
+                ItemFormat::Gcno,
                 false,
                 "rust/generics_with_two_parameters",
                 true,
             ),
-            (ItemFormat::GCNO, true, "reader_gcc-6_1.gcno", true),
-            (ItemFormat::GCNO, true, "reader_gcc-7_1.gcno", true),
-            (ItemFormat::GCNO, true, "reader_gcc-8_1.gcno", true),
-            (ItemFormat::GCNO, true, "reader_gcc-9_1.gcno", true),
-            (ItemFormat::GCNO, true, "reader_gcc-10_1.gcno", true),
-            (ItemFormat::INFO, false, "1494603973-2977-7.info", false),
-            (ItemFormat::INFO, false, "prova.info", false),
-            (ItemFormat::INFO, false, "prova_fn_with_commas.info", false),
-            (ItemFormat::INFO, false, "empty_line.info", false),
-            (ItemFormat::INFO, false, "invalid_DA_record.info", false),
+            (ItemFormat::Gcno, true, "reader_gcc-6_1.gcno", true),
+            (ItemFormat::Gcno, true, "reader_gcc-7_1.gcno", true),
+            (ItemFormat::Gcno, true, "reader_gcc-8_1.gcno", true),
+            (ItemFormat::Gcno, true, "reader_gcc-9_1.gcno", true),
+            (ItemFormat::Gcno, true, "reader_gcc-10_1.gcno", true),
+            (ItemFormat::Info, false, "1494603973-2977-7.info", false),
+            (ItemFormat::Info, false, "prova.info", false),
+            (ItemFormat::Info, false, "prova_fn_with_commas.info", false),
+            (ItemFormat::Info, false, "empty_line.info", false),
+            (ItemFormat::Info, false, "invalid_DA_record.info", false),
             (
-                ItemFormat::INFO,
+                ItemFormat::Info,
                 false,
                 "relative_path/relative_path.info",
                 false,
             ),
-            (ItemFormat::GCNO, false, "llvm/file", true),
-            (ItemFormat::GCNO, false, "llvm/file_branch", true),
-            (ItemFormat::GCNO, false, "llvm/reader", true),
+            (ItemFormat::Gcno, false, "llvm/file", true),
+            (ItemFormat::Gcno, false, "llvm/file_branch", true),
+            (ItemFormat::Gcno, false, "llvm/reader", true),
             (
-                ItemFormat::JACOCO_XML,
+                ItemFormat::JacocoXml,
                 false,
                 "jacoco/basic-jacoco.xml",
                 false,
             ),
             (
-                ItemFormat::JACOCO_XML,
+                ItemFormat::JacocoXml,
                 false,
                 "jacoco/inner-classes.xml",
                 false,
             ),
             (
-                ItemFormat::JACOCO_XML,
+                ItemFormat::JacocoXml,
                 false,
                 "jacoco/multiple-top-level-classes.xml",
                 false,
             ),
             (
-                ItemFormat::JACOCO_XML,
+                ItemFormat::JacocoXml,
                 false,
                 "jacoco/full-junit4-report-multiple-top-level-classes.xml",
                 false,
             ),
-            (ItemFormat::PROFRAW, true, "default_1.profraw", false),
+            (ItemFormat::Profraw, true, "default_1.profraw", false),
         ];
 
         check_produced(tmp_path, &receiver, expected);
@@ -788,8 +786,8 @@ mod tests {
         );
 
         let expected = vec![
-            (ItemFormat::GCNO, true, "RootAccessibleWrap_1.gcno", true),
-            (ItemFormat::GCNO, true, "prova2_1.gcno", true),
+            (ItemFormat::Gcno, true, "RootAccessibleWrap_1.gcno", true),
+            (ItemFormat::Gcno, true, "prova2_1.gcno", true),
         ];
 
         check_produced(tmp_path, &receiver, expected);
@@ -810,7 +808,7 @@ mod tests {
             false,
         );
 
-        let expected = vec![(ItemFormat::GCNO, true, "main_1.gcno", true)];
+        let expected = vec![(ItemFormat::Gcno, true, "main_1.gcno", true)];
 
         check_produced(tmp_path, &receiver, expected);
         assert!(mapping.is_none());
@@ -831,8 +829,8 @@ mod tests {
         );
 
         let expected = vec![
-            (ItemFormat::GCNO, true, "main_1.gcno", true),
-            (ItemFormat::GCNO, true, "orphan_1.gcno", false),
+            (ItemFormat::Gcno, true, "main_1.gcno", true),
+            (ItemFormat::Gcno, true, "orphan_1.gcno", false),
         ];
 
         check_produced(tmp_path, &receiver, expected);
@@ -853,7 +851,7 @@ mod tests {
             false,
         );
 
-        let expected = vec![(ItemFormat::GCNO, true, "main_1.gcno", true)];
+        let expected = vec![(ItemFormat::Gcno, true, "main_1.gcno", true)];
 
         check_produced(tmp_path, &receiver, expected);
         assert!(mapping.is_none());
@@ -877,22 +875,22 @@ mod tests {
         );
 
         let expected = vec![
-            (ItemFormat::GCNO, true, "Platform_1.gcno", true),
+            (ItemFormat::Gcno, true, "Platform_1.gcno", true),
             (
-                ItemFormat::GCNO,
+                ItemFormat::Gcno,
                 true,
                 "sub2/RootAccessibleWrap_1.gcno",
                 true,
             ),
-            (ItemFormat::GCNO, true, "nsMaiInterfaceValue_1.gcno", true),
-            (ItemFormat::GCNO, true, "sub/prova2_1.gcno", true),
+            (ItemFormat::Gcno, true, "nsMaiInterfaceValue_1.gcno", true),
+            (ItemFormat::Gcno, true, "sub/prova2_1.gcno", true),
             (
-                ItemFormat::GCNO,
+                ItemFormat::Gcno,
                 true,
                 "nsMaiInterfaceDocument_1.gcno",
                 true,
             ),
-            (ItemFormat::GCNO, true, "nsGnomeModule_1.gcno", true),
+            (ItemFormat::Gcno, true, "nsGnomeModule_1.gcno", true),
         ];
 
         check_produced(tmp_path, &receiver, expected);
@@ -928,31 +926,31 @@ mod tests {
         );
 
         let expected = vec![
-            (ItemFormat::GCNO, true, "Platform_1.gcno", true),
+            (ItemFormat::Gcno, true, "Platform_1.gcno", true),
             (
-                ItemFormat::GCNO,
+                ItemFormat::Gcno,
                 true,
                 "sub2/RootAccessibleWrap_1.gcno",
                 true,
             ),
-            (ItemFormat::GCNO, true, "nsMaiInterfaceValue_1.gcno", true),
-            (ItemFormat::GCNO, true, "sub/prova2_1.gcno", true),
+            (ItemFormat::Gcno, true, "nsMaiInterfaceValue_1.gcno", true),
+            (ItemFormat::Gcno, true, "sub/prova2_1.gcno", true),
             (
-                ItemFormat::GCNO,
+                ItemFormat::Gcno,
                 true,
                 "nsMaiInterfaceDocument_1.gcno",
                 true,
             ),
-            (ItemFormat::GCNO, true, "nsGnomeModule_1.gcno", true),
-            (ItemFormat::GCNO, true, "nsMaiInterfaceValue_2.gcno", true),
+            (ItemFormat::Gcno, true, "nsGnomeModule_1.gcno", true),
+            (ItemFormat::Gcno, true, "nsMaiInterfaceValue_2.gcno", true),
             (
-                ItemFormat::GCNO,
+                ItemFormat::Gcno,
                 true,
                 "nsMaiInterfaceDocument_2.gcno",
                 true,
             ),
-            (ItemFormat::GCNO, true, "nsGnomeModule_2.gcno", true),
-            (ItemFormat::GCNO, true, "sub/prova2_2.gcno", true),
+            (ItemFormat::Gcno, true, "nsGnomeModule_2.gcno", true),
+            (ItemFormat::Gcno, true, "sub/prova2_2.gcno", true),
         ];
 
         check_produced(tmp_path, &receiver, expected);
@@ -987,22 +985,22 @@ mod tests {
         );
 
         let expected = vec![
-            (ItemFormat::GCNO, true, "Platform_1.gcno", true),
+            (ItemFormat::Gcno, true, "Platform_1.gcno", true),
             (
-                ItemFormat::GCNO,
+                ItemFormat::Gcno,
                 true,
                 "sub2/RootAccessibleWrap_1.gcno",
                 true,
             ),
-            (ItemFormat::GCNO, true, "nsMaiInterfaceValue_1.gcno", true),
-            (ItemFormat::GCNO, true, "sub/prova2_1.gcno", true),
+            (ItemFormat::Gcno, true, "nsMaiInterfaceValue_1.gcno", true),
+            (ItemFormat::Gcno, true, "sub/prova2_1.gcno", true),
             (
-                ItemFormat::GCNO,
+                ItemFormat::Gcno,
                 true,
                 "nsMaiInterfaceDocument_1.gcno",
                 true,
             ),
-            (ItemFormat::GCNO, true, "nsGnomeModule_1.gcno", true),
+            (ItemFormat::Gcno, true, "nsGnomeModule_1.gcno", true),
         ];
 
         check_produced(tmp_path, &receiver, expected);
@@ -1029,31 +1027,31 @@ mod tests {
         );
 
         let expected = vec![
-            (ItemFormat::GCNO, true, "Platform_1.gcno", true),
+            (ItemFormat::Gcno, true, "Platform_1.gcno", true),
             (
-                ItemFormat::GCNO,
+                ItemFormat::Gcno,
                 true,
                 "sub2/RootAccessibleWrap_1.gcno",
                 true,
             ),
-            (ItemFormat::GCNO, true, "nsMaiInterfaceValue_1.gcno", true),
-            (ItemFormat::GCNO, true, "sub/prova2_1.gcno", true),
+            (ItemFormat::Gcno, true, "nsMaiInterfaceValue_1.gcno", true),
+            (ItemFormat::Gcno, true, "sub/prova2_1.gcno", true),
             (
-                ItemFormat::GCNO,
+                ItemFormat::Gcno,
                 true,
                 "nsMaiInterfaceDocument_1.gcno",
                 true,
             ),
-            (ItemFormat::GCNO, true, "nsGnomeModule_1.gcno", true),
-            (ItemFormat::GCNO, true, "nsMaiInterfaceValue_2.gcno", true),
+            (ItemFormat::Gcno, true, "nsGnomeModule_1.gcno", true),
+            (ItemFormat::Gcno, true, "nsMaiInterfaceValue_2.gcno", true),
             (
-                ItemFormat::GCNO,
+                ItemFormat::Gcno,
                 true,
                 "nsMaiInterfaceDocument_2.gcno",
                 true,
             ),
-            (ItemFormat::GCNO, true, "nsGnomeModule_2.gcno", true),
-            (ItemFormat::GCNO, true, "sub/prova2_2.gcno", true),
+            (ItemFormat::Gcno, true, "nsGnomeModule_2.gcno", true),
+            (ItemFormat::Gcno, true, "sub/prova2_2.gcno", true),
         ];
 
         check_produced(tmp_path, &receiver, expected);
@@ -1078,8 +1076,8 @@ mod tests {
         );
 
         let expected = vec![
-            (ItemFormat::PROFRAW, true, "default_1.profraw", false),
-            (ItemFormat::PROFRAW, true, "default_2.profraw", false),
+            (ItemFormat::Profraw, true, "default_1.profraw", false),
+            (ItemFormat::Profraw, true, "default_2.profraw", false),
         ];
 
         check_produced(tmp_path, &receiver, expected);
@@ -1101,18 +1099,18 @@ mod tests {
         );
 
         let expected = vec![
-            (ItemFormat::INFO, false, "1494603967-2977-2_0.info", true),
-            (ItemFormat::INFO, false, "1494603967-2977-3_0.info", true),
-            (ItemFormat::INFO, false, "1494603967-2977-4_0.info", true),
-            (ItemFormat::INFO, false, "1494603968-2977-5_0.info", true),
-            (ItemFormat::INFO, false, "1494603972-2977-6_0.info", true),
-            (ItemFormat::INFO, false, "1494603973-2977-7_0.info", true),
-            (ItemFormat::INFO, false, "1494603967-2977-2_1.info", true),
-            (ItemFormat::INFO, false, "1494603967-2977-3_1.info", true),
-            (ItemFormat::INFO, false, "1494603967-2977-4_1.info", true),
-            (ItemFormat::INFO, false, "1494603968-2977-5_1.info", true),
-            (ItemFormat::INFO, false, "1494603972-2977-6_1.info", true),
-            (ItemFormat::INFO, false, "1494603973-2977-7_1.info", true),
+            (ItemFormat::Info, false, "1494603967-2977-2_0.info", true),
+            (ItemFormat::Info, false, "1494603967-2977-3_0.info", true),
+            (ItemFormat::Info, false, "1494603967-2977-4_0.info", true),
+            (ItemFormat::Info, false, "1494603968-2977-5_0.info", true),
+            (ItemFormat::Info, false, "1494603972-2977-6_0.info", true),
+            (ItemFormat::Info, false, "1494603973-2977-7_0.info", true),
+            (ItemFormat::Info, false, "1494603967-2977-2_1.info", true),
+            (ItemFormat::Info, false, "1494603967-2977-3_1.info", true),
+            (ItemFormat::Info, false, "1494603967-2977-4_1.info", true),
+            (ItemFormat::Info, false, "1494603968-2977-5_1.info", true),
+            (ItemFormat::Info, false, "1494603972-2977-6_1.info", true),
+            (ItemFormat::Info, false, "1494603973-2977-7_1.info", true),
         ];
 
         check_produced(tmp_path, &receiver, expected);
@@ -1138,12 +1136,12 @@ mod tests {
 
         let expected = vec![
             (
-                ItemFormat::JACOCO_XML,
+                ItemFormat::JacocoXml,
                 false,
                 "jacoco/basic-jacoco.xml",
                 true,
             ),
-            (ItemFormat::JACOCO_XML, false, "inner-classes.xml", true),
+            (ItemFormat::JacocoXml, false, "inner-classes.xml", true),
         ];
 
         check_produced(tmp_path, &receiver, expected);
@@ -1171,24 +1169,24 @@ mod tests {
 
         let expected = vec![
             (
-                ItemFormat::JACOCO_XML,
+                ItemFormat::JacocoXml,
                 false,
                 "jacoco/basic-jacoco.xml",
                 true,
             ),
-            (ItemFormat::JACOCO_XML, false, "inner-classes.xml", true),
-            (ItemFormat::INFO, false, "1494603967-2977-2_0.info", true),
-            (ItemFormat::INFO, false, "1494603967-2977-3_0.info", true),
-            (ItemFormat::INFO, false, "1494603967-2977-4_0.info", true),
-            (ItemFormat::INFO, false, "1494603968-2977-5_0.info", true),
-            (ItemFormat::INFO, false, "1494603972-2977-6_0.info", true),
-            (ItemFormat::INFO, false, "1494603973-2977-7_0.info", true),
-            (ItemFormat::INFO, false, "1494603967-2977-2_1.info", true),
-            (ItemFormat::INFO, false, "1494603967-2977-3_1.info", true),
-            (ItemFormat::INFO, false, "1494603967-2977-4_1.info", true),
-            (ItemFormat::INFO, false, "1494603968-2977-5_1.info", true),
-            (ItemFormat::INFO, false, "1494603972-2977-6_1.info", true),
-            (ItemFormat::INFO, false, "1494603973-2977-7_1.info", true),
+            (ItemFormat::JacocoXml, false, "inner-classes.xml", true),
+            (ItemFormat::Info, false, "1494603967-2977-2_0.info", true),
+            (ItemFormat::Info, false, "1494603967-2977-3_0.info", true),
+            (ItemFormat::Info, false, "1494603967-2977-4_0.info", true),
+            (ItemFormat::Info, false, "1494603968-2977-5_0.info", true),
+            (ItemFormat::Info, false, "1494603972-2977-6_0.info", true),
+            (ItemFormat::Info, false, "1494603973-2977-7_0.info", true),
+            (ItemFormat::Info, false, "1494603967-2977-2_1.info", true),
+            (ItemFormat::Info, false, "1494603967-2977-3_1.info", true),
+            (ItemFormat::Info, false, "1494603967-2977-4_1.info", true),
+            (ItemFormat::Info, false, "1494603968-2977-5_1.info", true),
+            (ItemFormat::Info, false, "1494603972-2977-6_1.info", true),
+            (ItemFormat::Info, false, "1494603973-2977-7_1.info", true),
         ];
 
         check_produced(tmp_path, &receiver, expected);
@@ -1215,34 +1213,34 @@ mod tests {
         );
 
         let expected = vec![
-            (ItemFormat::GCNO, true, "Platform_1.gcno", true),
+            (ItemFormat::Gcno, true, "Platform_1.gcno", true),
             (
-                ItemFormat::GCNO,
+                ItemFormat::Gcno,
                 true,
                 "sub2/RootAccessibleWrap_1.gcno",
                 true,
             ),
-            (ItemFormat::GCNO, true, "nsMaiInterfaceValue_1.gcno", true),
-            (ItemFormat::GCNO, true, "sub/prova2_1.gcno", true),
+            (ItemFormat::Gcno, true, "nsMaiInterfaceValue_1.gcno", true),
+            (ItemFormat::Gcno, true, "sub/prova2_1.gcno", true),
             (
-                ItemFormat::GCNO,
+                ItemFormat::Gcno,
                 true,
                 "nsMaiInterfaceDocument_1.gcno",
                 true,
             ),
-            (ItemFormat::GCNO, true, "nsGnomeModule_1.gcno", true),
-            (ItemFormat::INFO, false, "1494603967-2977-2_0.info", true),
-            (ItemFormat::INFO, false, "1494603967-2977-3_0.info", true),
-            (ItemFormat::INFO, false, "1494603967-2977-4_0.info", true),
-            (ItemFormat::INFO, false, "1494603968-2977-5_0.info", true),
-            (ItemFormat::INFO, false, "1494603972-2977-6_0.info", true),
-            (ItemFormat::INFO, false, "1494603973-2977-7_0.info", true),
-            (ItemFormat::INFO, false, "1494603967-2977-2_1.info", true),
-            (ItemFormat::INFO, false, "1494603967-2977-3_1.info", true),
-            (ItemFormat::INFO, false, "1494603967-2977-4_1.info", true),
-            (ItemFormat::INFO, false, "1494603968-2977-5_1.info", true),
-            (ItemFormat::INFO, false, "1494603972-2977-6_1.info", true),
-            (ItemFormat::INFO, false, "1494603973-2977-7_1.info", true),
+            (ItemFormat::Gcno, true, "nsGnomeModule_1.gcno", true),
+            (ItemFormat::Info, false, "1494603967-2977-2_0.info", true),
+            (ItemFormat::Info, false, "1494603967-2977-3_0.info", true),
+            (ItemFormat::Info, false, "1494603967-2977-4_0.info", true),
+            (ItemFormat::Info, false, "1494603968-2977-5_0.info", true),
+            (ItemFormat::Info, false, "1494603972-2977-6_0.info", true),
+            (ItemFormat::Info, false, "1494603973-2977-7_0.info", true),
+            (ItemFormat::Info, false, "1494603967-2977-2_1.info", true),
+            (ItemFormat::Info, false, "1494603967-2977-3_1.info", true),
+            (ItemFormat::Info, false, "1494603967-2977-4_1.info", true),
+            (ItemFormat::Info, false, "1494603968-2977-5_1.info", true),
+            (ItemFormat::Info, false, "1494603972-2977-6_1.info", true),
+            (ItemFormat::Info, false, "1494603973-2977-7_1.info", true),
         ];
 
         check_produced(tmp_path, &receiver, expected);
@@ -1266,7 +1264,7 @@ mod tests {
             false,
         );
 
-        let expected = vec![(ItemFormat::GCNO, true, "main_1.gcno", false)];
+        let expected = vec![(ItemFormat::Gcno, true, "main_1.gcno", false)];
 
         check_produced(tmp_path, &receiver, expected);
         assert!(mapping.is_none());
@@ -1291,7 +1289,7 @@ mod tests {
             false,
         );
 
-        let expected = vec![(ItemFormat::GCNO, true, "main_1.gcno", true)];
+        let expected = vec![(ItemFormat::Gcno, true, "main_1.gcno", true)];
 
         check_produced(tmp_path, &receiver, expected);
         assert!(mapping.is_none());
@@ -1330,22 +1328,22 @@ mod tests {
         );
 
         let expected = vec![
-            (ItemFormat::GCNO, true, "Platform_1.gcno", false),
+            (ItemFormat::Gcno, true, "Platform_1.gcno", false),
             (
-                ItemFormat::GCNO,
+                ItemFormat::Gcno,
                 true,
                 "sub2/RootAccessibleWrap_1.gcno",
                 false,
             ),
-            (ItemFormat::GCNO, true, "nsMaiInterfaceValue_1.gcno", true),
-            (ItemFormat::GCNO, true, "sub/prova2_1.gcno", true),
+            (ItemFormat::Gcno, true, "nsMaiInterfaceValue_1.gcno", true),
+            (ItemFormat::Gcno, true, "sub/prova2_1.gcno", true),
             (
-                ItemFormat::GCNO,
+                ItemFormat::Gcno,
                 true,
                 "nsMaiInterfaceDocument_1.gcno",
                 true,
             ),
-            (ItemFormat::GCNO, true, "nsGnomeModule_1.gcno", true),
+            (ItemFormat::Gcno, true, "nsGnomeModule_1.gcno", true),
         ];
 
         check_produced(tmp_path, &receiver, expected);
@@ -1372,31 +1370,31 @@ mod tests {
         );
 
         let expected = vec![
-            (ItemFormat::GCNO, true, "Platform_1.gcno", false),
+            (ItemFormat::Gcno, true, "Platform_1.gcno", false),
             (
-                ItemFormat::GCNO,
+                ItemFormat::Gcno,
                 true,
                 "sub2/RootAccessibleWrap_1.gcno",
                 false,
             ),
-            (ItemFormat::GCNO, true, "nsMaiInterfaceValue_1.gcno", true),
-            (ItemFormat::GCNO, true, "nsMaiInterfaceValue_2.gcno", true),
-            (ItemFormat::GCNO, true, "sub/prova2_1.gcno", true),
-            (ItemFormat::GCNO, true, "sub/prova2_2.gcno", true),
+            (ItemFormat::Gcno, true, "nsMaiInterfaceValue_1.gcno", true),
+            (ItemFormat::Gcno, true, "nsMaiInterfaceValue_2.gcno", true),
+            (ItemFormat::Gcno, true, "sub/prova2_1.gcno", true),
+            (ItemFormat::Gcno, true, "sub/prova2_2.gcno", true),
             (
-                ItemFormat::GCNO,
+                ItemFormat::Gcno,
                 true,
                 "nsMaiInterfaceDocument_1.gcno",
                 true,
             ),
             (
-                ItemFormat::GCNO,
+                ItemFormat::Gcno,
                 true,
                 "nsMaiInterfaceDocument_2.gcno",
                 true,
             ),
-            (ItemFormat::GCNO, true, "nsGnomeModule_1.gcno", true),
-            (ItemFormat::GCNO, true, "nsGnomeModule_2.gcno", true),
+            (ItemFormat::Gcno, true, "nsGnomeModule_1.gcno", true),
+            (ItemFormat::Gcno, true, "nsGnomeModule_2.gcno", true),
         ];
 
         check_produced(tmp_path, &receiver, expected);
@@ -1418,15 +1416,15 @@ mod tests {
         );
 
         let expected = vec![
-            (ItemFormat::GCNO, true, "nsMaiInterfaceValue_1.gcno", true),
-            (ItemFormat::GCNO, true, "sub/prova2_1.gcno", true),
+            (ItemFormat::Gcno, true, "nsMaiInterfaceValue_1.gcno", true),
+            (ItemFormat::Gcno, true, "sub/prova2_1.gcno", true),
             (
-                ItemFormat::GCNO,
+                ItemFormat::Gcno,
                 true,
                 "nsMaiInterfaceDocument_1.gcno",
                 true,
             ),
-            (ItemFormat::GCNO, true, "nsGnomeModule_1.gcno", true),
+            (ItemFormat::Gcno, true, "nsGnomeModule_1.gcno", true),
         ];
 
         check_produced(tmp_path, &receiver, expected);
@@ -1452,24 +1450,24 @@ mod tests {
         );
 
         let expected = vec![
-            (ItemFormat::GCNO, true, "nsMaiInterfaceValue_1.gcno", true),
-            (ItemFormat::GCNO, true, "nsMaiInterfaceValue_2.gcno", true),
-            (ItemFormat::GCNO, true, "sub/prova2_1.gcno", true),
-            (ItemFormat::GCNO, true, "sub/prova2_2.gcno", true),
+            (ItemFormat::Gcno, true, "nsMaiInterfaceValue_1.gcno", true),
+            (ItemFormat::Gcno, true, "nsMaiInterfaceValue_2.gcno", true),
+            (ItemFormat::Gcno, true, "sub/prova2_1.gcno", true),
+            (ItemFormat::Gcno, true, "sub/prova2_2.gcno", true),
             (
-                ItemFormat::GCNO,
+                ItemFormat::Gcno,
                 true,
                 "nsMaiInterfaceDocument_1.gcno",
                 true,
             ),
             (
-                ItemFormat::GCNO,
+                ItemFormat::Gcno,
                 true,
                 "nsMaiInterfaceDocument_2.gcno",
                 true,
             ),
-            (ItemFormat::GCNO, true, "nsGnomeModule_1.gcno", true),
-            (ItemFormat::GCNO, true, "nsGnomeModule_2.gcno", true),
+            (ItemFormat::Gcno, true, "nsGnomeModule_1.gcno", true),
+            (ItemFormat::Gcno, true, "nsGnomeModule_2.gcno", true),
         ];
 
         check_produced(tmp_path, &receiver, expected);
@@ -1522,14 +1520,12 @@ mod tests {
             if let ItemType::Buffers(buffers) = elem.item {
                 let stem = PathBuf::from(buffers.stem);
                 let stem = stem.file_stem().expect("Unable to get file_stem");
-                if stem == "file" {
-                    assert_eq!(buffers.gcno_buf, gcno_buf);
-                    assert_eq!(buffers.gcda_buf, vec![gcda1_buf.clone(), gcda2_buf.clone()]);
-                } else {
-                    assert!(false, "Unexpected file: {:?}", stem);
-                }
+
+                assert!(stem == "file", "Unexpected file: {:?}", stem);
+                assert_eq!(buffers.gcno_buf, gcno_buf);
+                assert_eq!(buffers.gcda_buf, vec![gcda1_buf.clone(), gcda2_buf.clone()]);
             } else {
-                assert!(false, "Buffers expected");
+                panic!("Buffers expected");
             }
         }
     }
@@ -1552,14 +1548,14 @@ mod tests {
         assert!(mapping.is_some());
         let mapping = mapping.unwrap();
 
-        let expected = vec![(ItemFormat::INFO, false, "prova_1.info", true)];
+        let expected = vec![(ItemFormat::Info, false, "prova_1.info", true)];
 
         if let Ok(mut reader) = File::open(json_path) {
             let mut json = Vec::new();
             reader.read_to_end(&mut json).unwrap();
             assert_eq!(json, mapping);
         } else {
-            assert!(false, "Failed to read the file: {}", json_path);
+            panic!("Failed to read the file: {}", json_path);
         }
 
         check_produced(tmp_path, &receiver, expected);
@@ -1579,7 +1575,7 @@ mod tests {
             false,
         );
 
-        let expected = vec![(ItemFormat::PROFRAW, true, "default.profraw", false)];
+        let expected = vec![(ItemFormat::Profraw, true, "default.profraw", false)];
 
         check_produced(PathBuf::from("test"), &receiver, expected);
     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -7,6 +7,7 @@ use std::fmt::{Debug, Display, Formatter};
 use std::fs::File;
 use std::io::{BufReader, Error, Read, Write};
 use std::marker::PhantomData;
+use std::path::Path;
 use std::path::PathBuf;
 use std::result::Result;
 
@@ -69,15 +70,14 @@ impl Endian for BigEndian {
 }
 
 enum FileType {
-    GCNO,
-    GCDA,
+    Gcno,
+    Gcda,
 }
 
 #[derive(Default)]
-pub struct GCNO {
+pub struct Gcno {
     version: u32,
     checksum: u32,
-    cwd: Option<String>,
     programcounts: u32,
     runcounts: u32,
     functions: Vec<GcovFunction>,
@@ -309,7 +309,7 @@ impl Display for GcovError {
     }
 }
 
-impl Debug for GCNO {
+impl Debug for Gcno {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         for fun in &self.functions {
             writeln!(
@@ -361,12 +361,11 @@ impl Debug for GCNO {
     }
 }
 
-impl GCNO {
+impl Gcno {
     pub fn new() -> Self {
-        GCNO {
+        Gcno {
             version: 0,
             checksum: 0,
-            cwd: None,
             programcounts: 0,
             runcounts: 0,
             functions: Vec::new(),
@@ -404,7 +403,7 @@ impl GCNO {
     fn read(&mut self, typ: FileType, buf: Vec<u8>, stem: &str) -> Result<(), GcovError> {
         let little_endian = Self::guess_endianness(
             match typ {
-                FileType::GCNO => *b"oncg",
+                FileType::Gcno => *b"oncg",
                 _ => *b"adcg",
             },
             &buf,
@@ -412,12 +411,12 @@ impl GCNO {
         )?;
         if little_endian {
             match typ {
-                FileType::GCNO => self.read_gcno(GcovReaderBuf::<LittleEndian>::new(stem, buf)),
+                FileType::Gcno => self.read_gcno(GcovReaderBuf::<LittleEndian>::new(stem, buf)),
                 _ => self.read_gcda(GcovReaderBuf::<LittleEndian>::new(stem, buf)),
             }
         } else {
             match typ {
-                FileType::GCNO => self.read_gcno(GcovReaderBuf::<BigEndian>::new(stem, buf)),
+                FileType::Gcno => self.read_gcno(GcovReaderBuf::<BigEndian>::new(stem, buf)),
                 _ => self.read_gcda(GcovReaderBuf::<BigEndian>::new(stem, buf)),
             }
         }
@@ -430,9 +429,9 @@ impl GCNO {
         branch_enabled: bool,
     ) -> Result<Vec<(String, CovResult)>, GcovError> {
         let mut gcno = Self::new();
-        gcno.read(FileType::GCNO, gcno_buf, stem)?;
+        gcno.read(FileType::Gcno, gcno_buf, stem)?;
         for gcda_buf in gcda_bufs.drain(..) {
-            gcno.read(FileType::GCDA, gcda_buf, stem)?;
+            gcno.read(FileType::Gcda, gcda_buf, stem)?;
         }
         gcno.stop();
         Ok(gcno.finalize(branch_enabled))
@@ -451,7 +450,8 @@ impl GCNO {
         self.version = reader.read_version()?;
         self.checksum = reader.read_u32()?;
         if self.version >= 90 {
-            self.cwd = Some(reader.read_string()?);
+            // read the cwd.
+            reader.read_string()?;
         }
         if self.version >= 80 {
             // hasUnexecutedBlocks
@@ -633,21 +633,21 @@ impl GCNO {
                 } else {
                     continue;
                 };
-                GCNO::read_blocks(fun, length, self.version, reader)?;
+                Gcno::read_blocks(fun, length, self.version, reader)?;
             } else if tag == GCOV_TAG_ARCS {
                 let fun = if let Some(fun) = self.functions.last_mut() {
                     fun
                 } else {
                     continue;
                 };
-                GCNO::read_edges(fun, length, reader)?;
+                Gcno::read_edges(fun, length, reader)?;
             } else if tag == GCOV_TAG_LINES {
                 let fun = if let Some(fun) = self.functions.last_mut() {
                     fun
                 } else {
                     continue;
                 };
-                GCNO::read_lines(fun, self.version, reader)?;
+                Gcno::read_lines(fun, self.version, reader)?;
             }
         }
         Ok(())
@@ -790,7 +790,7 @@ impl GCNO {
 
     pub fn dump(
         &mut self,
-        path: &PathBuf,
+        path: &Path,
         file_name: &str,
         writer: &mut dyn Write,
     ) -> Result<(), GcovError> {
@@ -1213,7 +1213,7 @@ mod tests {
     use super::*;
     use crate::defs::FunctionMap;
 
-    fn from_path(gcno: &mut GCNO, typ: FileType, path: &str) {
+    fn from_path(gcno: &mut Gcno, typ: FileType, path: &str) {
         let path = PathBuf::from(path);
         let mut f = File::open(&path).unwrap();
         let mut buf = Vec::new();
@@ -1239,8 +1239,8 @@ mod tests {
 
     #[test]
     fn test_reader_gcno() {
-        let mut gcno = GCNO::new();
-        from_path(&mut gcno, FileType::GCNO, "test/llvm/reader.gcno");
+        let mut gcno = Gcno::new();
+        from_path(&mut gcno, FileType::Gcno, "test/llvm/reader.gcno");
         let output = format!("{:?}", gcno);
         let input = get_input_string("test/llvm/reader.gcno.0.dump");
 
@@ -1249,9 +1249,9 @@ mod tests {
 
     #[test]
     fn test_reader_gcno_gcda() {
-        let mut gcno = GCNO::new();
-        from_path(&mut gcno, FileType::GCNO, "test/llvm/reader.gcno");
-        from_path(&mut gcno, FileType::GCDA, "test/llvm/reader.gcda");
+        let mut gcno = Gcno::new();
+        from_path(&mut gcno, FileType::Gcno, "test/llvm/reader.gcno");
+        from_path(&mut gcno, FileType::Gcda, "test/llvm/reader.gcda");
         gcno.stop();
         let output = format!("{:?}", gcno);
         let input = get_input_string("test/llvm/reader.gcno.1.dump");
@@ -1261,9 +1261,9 @@ mod tests {
 
     #[test]
     fn test_reader_gcno_gcda_gcc6() {
-        let mut gcno = GCNO::new();
-        from_path(&mut gcno, FileType::GCNO, "test/reader_gcc-6.gcno");
-        from_path(&mut gcno, FileType::GCDA, "test/reader_gcc-6.gcda");
+        let mut gcno = Gcno::new();
+        from_path(&mut gcno, FileType::Gcno, "test/reader_gcc-6.gcno");
+        from_path(&mut gcno, FileType::Gcda, "test/reader_gcc-6.gcda");
         gcno.stop();
         let output = format!("{:?}", gcno);
         let input = get_input_string("test/reader_gcc-6.gcno.1.dump");
@@ -1273,9 +1273,9 @@ mod tests {
 
     #[test]
     fn test_reader_gcno_gcda_gcc7() {
-        let mut gcno = GCNO::new();
-        from_path(&mut gcno, FileType::GCNO, "test/reader_gcc-7.gcno");
-        from_path(&mut gcno, FileType::GCDA, "test/reader_gcc-7.gcda");
+        let mut gcno = Gcno::new();
+        from_path(&mut gcno, FileType::Gcno, "test/reader_gcc-7.gcno");
+        from_path(&mut gcno, FileType::Gcda, "test/reader_gcc-7.gcda");
         gcno.stop();
         let output = format!("{:?}", gcno);
         let input = get_input_string("test/reader_gcc-7.gcno.1.dump");
@@ -1285,9 +1285,9 @@ mod tests {
 
     #[test]
     fn test_reader_gcno_gcda_gcc8() {
-        let mut gcno = GCNO::new();
-        from_path(&mut gcno, FileType::GCNO, "test/reader_gcc-8.gcno");
-        from_path(&mut gcno, FileType::GCDA, "test/reader_gcc-8.gcda");
+        let mut gcno = Gcno::new();
+        from_path(&mut gcno, FileType::Gcno, "test/reader_gcc-8.gcno");
+        from_path(&mut gcno, FileType::Gcda, "test/reader_gcc-8.gcda");
         gcno.stop();
         let output = format!("{:?}", gcno);
         let input = get_input_string("test/reader_gcc-8.gcno.1.dump");
@@ -1297,9 +1297,9 @@ mod tests {
 
     #[test]
     fn test_reader_gcno_gcda_gcc9() {
-        let mut gcno = GCNO::new();
-        from_path(&mut gcno, FileType::GCNO, "test/reader_gcc-9.gcno");
-        from_path(&mut gcno, FileType::GCDA, "test/reader_gcc-9.gcda");
+        let mut gcno = Gcno::new();
+        from_path(&mut gcno, FileType::Gcno, "test/reader_gcc-9.gcno");
+        from_path(&mut gcno, FileType::Gcda, "test/reader_gcc-9.gcda");
         gcno.stop();
         let output = format!("{:?}", gcno);
         let input = get_input_string("test/reader_gcc-9.gcno.1.dump");
@@ -1309,9 +1309,9 @@ mod tests {
 
     #[test]
     fn test_reader_gcno_gcda_gcc10() {
-        let mut gcno = GCNO::new();
-        from_path(&mut gcno, FileType::GCNO, "test/reader_gcc-10.gcno");
-        from_path(&mut gcno, FileType::GCDA, "test/reader_gcc-10.gcda");
+        let mut gcno = Gcno::new();
+        from_path(&mut gcno, FileType::Gcno, "test/reader_gcc-10.gcno");
+        from_path(&mut gcno, FileType::Gcda, "test/reader_gcc-10.gcda");
         gcno.stop();
         let output = format!("{:?}", gcno);
         let input = get_input_string("test/reader_gcc-10.gcno.1.dump");
@@ -1321,10 +1321,10 @@ mod tests {
 
     #[test]
     fn test_reader_gcno_gcda_gcda() {
-        let mut gcno = GCNO::new();
-        from_path(&mut gcno, FileType::GCNO, "test/llvm/reader.gcno");
+        let mut gcno = Gcno::new();
+        from_path(&mut gcno, FileType::Gcno, "test/llvm/reader.gcno");
         for _ in 0..2 {
-            from_path(&mut gcno, FileType::GCDA, "test/llvm/reader.gcda");
+            from_path(&mut gcno, FileType::Gcda, "test/llvm/reader.gcda");
         }
         gcno.stop();
         let output = format!("{:?}", gcno);
@@ -1335,8 +1335,8 @@ mod tests {
 
     #[test]
     fn test_reader_gcno_counter() {
-        let mut gcno = GCNO::new();
-        from_path(&mut gcno, FileType::GCNO, "test/llvm/reader.gcno");
+        let mut gcno = Gcno::new();
+        from_path(&mut gcno, FileType::Gcno, "test/llvm/reader.gcno");
         gcno.stop();
         let mut output = Vec::new();
         gcno.dump(
@@ -1352,9 +1352,9 @@ mod tests {
 
     #[test]
     fn test_reader_gcno_gcda_counter() {
-        let mut gcno = GCNO::new();
-        from_path(&mut gcno, FileType::GCNO, "test/llvm/reader.gcno");
-        from_path(&mut gcno, FileType::GCDA, "test/llvm/reader.gcda");
+        let mut gcno = Gcno::new();
+        from_path(&mut gcno, FileType::Gcno, "test/llvm/reader.gcno");
+        from_path(&mut gcno, FileType::Gcda, "test/llvm/reader.gcda");
         gcno.stop();
         let mut output = Vec::new();
         gcno.dump(
@@ -1370,10 +1370,10 @@ mod tests {
 
     #[test]
     fn test_reader_gcno_gcda_gcda_counter() {
-        let mut gcno = GCNO::new();
-        from_path(&mut gcno, FileType::GCNO, "test/llvm/reader.gcno");
+        let mut gcno = Gcno::new();
+        from_path(&mut gcno, FileType::Gcno, "test/llvm/reader.gcno");
         for _ in 0..2 {
-            from_path(&mut gcno, FileType::GCDA, "test/llvm/reader.gcda");
+            from_path(&mut gcno, FileType::Gcda, "test/llvm/reader.gcda");
         }
         gcno.stop();
         let mut output = Vec::new();
@@ -1390,9 +1390,9 @@ mod tests {
 
     #[test]
     fn test_reader_finalize_file() {
-        let mut gcno = GCNO::new();
-        from_path(&mut gcno, FileType::GCNO, "test/llvm/file.gcno");
-        from_path(&mut gcno, FileType::GCDA, "test/llvm/file.gcda");
+        let mut gcno = Gcno::new();
+        from_path(&mut gcno, FileType::Gcno, "test/llvm/file.gcno");
+        from_path(&mut gcno, FileType::Gcda, "test/llvm/file.gcda");
         gcno.stop();
         let result = gcno.finalize(true);
 
@@ -1410,9 +1410,9 @@ mod tests {
         let expected = vec![(
             String::from("file.c"),
             CovResult {
-                lines: lines,
-                branches: branches,
-                functions: functions,
+                lines,
+                branches,
+                functions,
             },
         )];
 
@@ -1421,9 +1421,9 @@ mod tests {
 
     #[test]
     fn test_reader_finalize_file_branch() {
-        let mut gcno = GCNO::new();
-        from_path(&mut gcno, FileType::GCNO, "test/llvm/file_branch.gcno");
-        from_path(&mut gcno, FileType::GCDA, "test/llvm/file_branch.gcda");
+        let mut gcno = Gcno::new();
+        from_path(&mut gcno, FileType::Gcno, "test/llvm/file_branch.gcno");
+        from_path(&mut gcno, FileType::Gcda, "test/llvm/file_branch.gcda");
         gcno.stop();
         let result = gcno.finalize(true);
 
@@ -1497,9 +1497,9 @@ mod tests {
         let expected = vec![(
             String::from("file_branch.c"),
             CovResult {
-                lines: lines,
-                branches: branches,
-                functions: functions,
+                lines,
+                branches,
+                functions,
             },
         )];
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -78,6 +78,7 @@ enum FileType {
 pub struct Gcno {
     version: u32,
     checksum: u32,
+    #[allow(dead_code)]
     cwd: Option<String>,
     programcounts: u32,
     runcounts: u32,
@@ -283,7 +284,7 @@ impl<E: Endian> GcovReader<E> for GcovReaderBuf<E> {
                 let bytes = &self.buffer[i..i + 4];
                 Err(GcovError::Str(format!(
                     "Unexpected version: {} in {}",
-                    String::from_utf8_lossy(&bytes),
+                    String::from_utf8_lossy(bytes),
                     self.get_stem()
                 )))
             }
@@ -389,7 +390,7 @@ impl Gcno {
                 } else {
                     Err(GcovError::Str(format!(
                         "Unexpected file type: {} in {}.",
-                        std::str::from_utf8(&bytes).unwrap(),
+                        std::str::from_utf8(bytes).unwrap(),
                         stem
                     )))
                 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -78,6 +78,7 @@ enum FileType {
 pub struct Gcno {
     version: u32,
     checksum: u32,
+    cwd: Option<String>,
     programcounts: u32,
     runcounts: u32,
     functions: Vec<GcovFunction>,
@@ -366,6 +367,7 @@ impl Gcno {
         Gcno {
             version: 0,
             checksum: 0,
+            cwd: None,
             programcounts: 0,
             runcounts: 0,
             functions: Vec::new(),
@@ -450,8 +452,7 @@ impl Gcno {
         self.version = reader.read_version()?;
         self.checksum = reader.read_u32()?;
         if self.version >= 90 {
-            // read the cwd.
-            reader.read_string()?;
+            self.cwd = Some(reader.read_string()?);
         }
         if self.version >= 80 {
             // hasUnexecutedBlocks

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -573,32 +573,26 @@ fn test_integration_zip_zip() {
         // no gcda
         println!("No gcda");
         check_equal_coveralls(
-            &read_expected(
-                path,
-                &name,
-                &compiler_version,
-                "coveralls",
-                Some("_no_gcda"),
-            ),
+            &read_expected(path, name, &compiler_version, "coveralls", Some("_no_gcda")),
             &run_grcov(vec![&gcno_zip_path, &gcda0_zip_path], path, "coveralls"),
             false,
         );
 
         check_equal_covdir(
-            &read_expected(path, &name, &compiler_version, "covdir", Some("_no_gcda")),
+            &read_expected(path, name, &compiler_version, "covdir", Some("_no_gcda")),
             &run_grcov(vec![&gcno_zip_path, &gcda0_zip_path], path, "covdir"),
         );
 
         // one gcda
         println!("One gcda");
         check_equal_coveralls(
-            &read_expected(path, &name, &compiler_version, "coveralls", None),
+            &read_expected(path, name, &compiler_version, "coveralls", None),
             &run_grcov(vec![&gcno_zip_path, &gcda_zip_path], path, "coveralls"),
             false,
         );
 
         check_equal_covdir(
-            &read_expected(path, &name, &compiler_version, "covdir", None),
+            &read_expected(path, name, &compiler_version, "covdir", None),
             &run_grcov(vec![&gcno_zip_path, &gcda_zip_path], path, "covdir"),
         );
 
@@ -610,7 +604,7 @@ fn test_integration_zip_zip() {
         check_equal_coveralls(
             &read_expected(
                 path,
-                &name,
+                name,
                 &compiler_version,
                 "coveralls",
                 Some("_two_gcda"),
@@ -624,7 +618,7 @@ fn test_integration_zip_zip() {
         );
 
         check_equal_covdir(
-            &read_expected(path, &name, &compiler_version, "covdir", Some("_two_gcda")),
+            &read_expected(path, name, &compiler_version, "covdir", Some("_two_gcda")),
             &run_grcov(
                 vec![&gcno_zip_path, &gcda_zip_path, &gcda1_zip_path],
                 path,
@@ -668,14 +662,14 @@ fn test_integration_zip_dir() {
         let gcno_zip_path = path.join(gcno_zip_path);
 
         check_equal_coveralls(
-            &read_expected(base_path, &name, &compiler_version, "coveralls", None),
-            &run_grcov(vec![&gcno_zip_path, &base_path], path, "coveralls"),
+            &read_expected(base_path, name, &compiler_version, "coveralls", None),
+            &run_grcov(vec![&gcno_zip_path, base_path], path, "coveralls"),
             false,
         );
 
         check_equal_covdir(
-            &read_expected(base_path, &name, &compiler_version, "covdir", None),
-            &run_grcov(vec![&gcno_zip_path, &base_path], path, "covdir"),
+            &read_expected(base_path, name, &compiler_version, "covdir", None),
+            &run_grcov(vec![&gcno_zip_path, base_path], path, "covdir"),
         );
 
         do_clean(path);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -69,7 +69,8 @@ fn run(path: &Path) {
 
 fn read_file(path: &Path) -> String {
     println!("Read file: {:?}", path);
-    let mut f = File::open(path).expect(format!("{:?} file not found", path.file_name()).as_str());
+    let mut f =
+        File::open(path).unwrap_or_else(|_| panic!("{:?} file not found", path.file_name()));
     let mut s = String::new();
     f.read_to_string(&mut s).unwrap();
     s
@@ -374,7 +375,7 @@ fn check_equal_covdir(expected_output: &str, output: &str) {
 
     println!("{}", serde_json::to_string_pretty(&actual).unwrap());
 
-    for field in vec![
+    for field in &[
         "coveragePercent",
         "linesCovered",
         "linesMissed",
@@ -400,7 +401,7 @@ fn get_version(compiler: &str) -> String {
     get_compiler_major(&version)
 }
 
-fn get_compiler_major(version: &String) -> String {
+fn get_compiler_major(version: &str) -> String {
     let re = Regex::new(r"(?:version |(?:gcc \([^\)]+\) )*)([0-9]+)\.[0-9]+\.[0-9]+").unwrap();
     match re.captures(version) {
         Some(caps) => caps.get(1).unwrap().as_str().to_string(),
@@ -420,18 +421,19 @@ fn create_zip(zip_path: &Path, base_dir: &Path, base_dir_in_zip: Option<&str>, f
         }
     }
 
-    let zipfile =
-        File::create(base_dir.join(zip_path)).expect(&format!("Cannot create file {:?}", zip_path));
+    let zipfile = File::create(base_dir.join(zip_path))
+        .unwrap_or_else(|_| panic!("Cannot create file {:?}", zip_path));
     let mut zip = ZipWriter::new(zipfile);
     for ref file_path in files {
-        let mut file = File::open(file_path).expect(&format!("Cannot open file {:?}", file_path));
+        let mut file =
+            File::open(file_path).unwrap_or_else(|_| panic!("Cannot open file {:?}", file_path));
         let file_size = file
             .metadata()
-            .expect(&format!("Cannot get metadata for {:?}", file_path))
+            .unwrap_or_else(|_| panic!("Cannot get metadata for {:?}", file_path))
             .len() as usize;
         let mut content: Vec<u8> = Vec::with_capacity(file_size + 1);
         file.read_to_end(&mut content)
-            .expect(&format!("Cannot read {:?}", file_path));
+            .unwrap_or_else(|_| panic!("Cannot read {:?}", file_path));
 
         let filename_in_zip = file_path.file_name().unwrap().to_str().unwrap();
         let filename_in_zip = match base_dir_in_zip {
@@ -440,29 +442,26 @@ fn create_zip(zip_path: &Path, base_dir: &Path, base_dir_in_zip: Option<&str>, f
         };
 
         zip.start_file(filename_in_zip, FileOptions::default())
-            .expect(&format!("Cannot create zip for {:?}", zip_path));
+            .unwrap_or_else(|_| panic!("Cannot create zip for {:?}", zip_path));
         zip.write_all(content.as_slice())
-            .expect(&format!("Cannot write {:?}", zip_path));
+            .unwrap_or_else(|_| panic!("Cannot write {:?}", zip_path));
     }
 
-    match base_dir_in_zip {
-        Some(path) => {
-            let path = PathBuf::from(path);
-            let mut path = Some(path.as_path());
-            while let Some(parent) = path {
-                let ancestor = parent.to_str().unwrap();
-                if !ancestor.is_empty() {
-                    zip.add_directory(ancestor, FileOptions::default())
-                        .expect(&format!("Cannot add a directory"));
-                }
-                path = parent.parent();
+    if let Some(path) = base_dir_in_zip {
+        let path = PathBuf::from(path);
+        let mut path = Some(path.as_path());
+        while let Some(parent) = path {
+            let ancestor = parent.to_str().unwrap();
+            if !ancestor.is_empty() {
+                zip.add_directory(ancestor, FileOptions::default())
+                    .unwrap_or_else(|_| panic!("Cannot add a directory"));
             }
+            path = parent.parent();
         }
-        None => {}
     }
 
     zip.finish()
-        .expect(&format!("Unable to write zip structure for {:?}", zip_path));
+        .unwrap_or_else(|_| panic!("Unable to write zip structure for {:?}", zip_path));
 }
 
 #[test]
@@ -551,12 +550,7 @@ fn test_integration_zip_zip() {
         let path = &PathBuf::from("tests/basic_zip_zip");
 
         println!("\n{}", name.to_uppercase());
-        let compiler_version = if is_llvm {
-            let clang_version = get_version(&compiler);
-            clang_version
-        } else {
-            get_version(&compiler)
-        };
+        let compiler_version = get_version(&compiler);
 
         do_clean(path);
         make(path, &compiler);
@@ -610,7 +604,7 @@ fn test_integration_zip_zip() {
 
         // two gcdas
         std::fs::copy(&gcda_zip_path, &gcda1_zip_path)
-            .expect(&format!("Failed to copy {:?}", &gcda_zip_path));
+            .unwrap_or_else(|_| panic!("Failed to copy {:?}", &gcda_zip_path));
 
         println!("Two gcdas");
         check_equal_coveralls(
@@ -658,12 +652,7 @@ fn test_integration_zip_dir() {
         let path = &base_path.join("foo_dir").join("bar_dir");
 
         println!("\n{}", name.to_uppercase());
-        let compiler_version = if is_llvm {
-            let clang_version = get_version(&compiler);
-            clang_version
-        } else {
-            get_version(&compiler)
-        };
+        let compiler_version = get_version(&compiler);
 
         do_clean(path);
         make(path, &compiler);


### PR DESCRIPTION
Currently clippy reports many warnings. This PR fixes all of them with the exception of a  
few being allowed now as it bring any benefit to adjust to them.

While doing so I replaced many usages of `PathBuf` with `&Path` as well.