### PR TITLE
Update semver to 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ dependencies = [
  "rayon",
  "regex",
  "rustc-hash",
- "semver 0.11.0",
+ "semver 1.0.3",
  "serde",
  "serde_derive",
  "serde_json",
@@ -986,7 +986,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser 0.7.0",
+ "semver-parser",
 ]
 
 [[package]]
@@ -995,33 +995,21 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
 dependencies = [
- "semver-parser 0.7.0",
+ "semver-parser",
  "serde",
 ]
 
 [[package]]
 name = "semver"
-version = "0.11.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser 0.10.2",
-]
+checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
 
 [[package]]
 name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ serde_derive = "^1.0"
 serde_json = "^1.0"
 walkdir = "^2.3"
 num_cpus = "^1.13"
-semver = "^0.11"
+semver = "^1.0"
 md-5 = "^0.9"
 zip = { version = "^0.5", default-features = false }
 tempfile = "^3"

--- a/src/gcov.rs
+++ b/src/gcov.rs
@@ -82,13 +82,7 @@ pub fn get_gcov_version() -> &'static Version {
 pub fn get_gcov_output_ext() -> &'static str {
     lazy_static! {
         static ref E: &'static str = {
-            let min_ver = Version {
-                major: 9,
-                minor: 1,
-                patch: 0,
-                pre: vec![],
-                build: vec![],
-            };
+            let min_ver = Version::new(9, 1, 0);
             if get_gcov_version() >= &min_ver {
                 ".gcov.json.gz"
             } else {
@@ -117,33 +111,15 @@ mod tests {
     fn test_parse_version() {
         assert_eq!(
             parse_version("gcov (Ubuntu 4.3.0-12ubuntu2) 4.3.0 20170406"),
-            Version {
-                major: 4,
-                minor: 3,
-                patch: 0,
-                pre: vec![],
-                build: vec![],
-            }
+            Version::new(4, 3, 0)
         );
         assert_eq!(
             parse_version("gcov (Ubuntu 4.9.0-12ubuntu2) 4.9.0 20170406"),
-            Version {
-                major: 4,
-                minor: 9,
-                patch: 0,
-                pre: vec![],
-                build: vec![],
-            }
+            Version::new(4, 9, 0)
         );
         assert_eq!(
             parse_version("gcov (Ubuntu 6.3.0-12ubuntu2) 6.3.0 20170406"),
-            Version {
-                major: 6,
-                minor: 3,
-                patch: 0,
-                pre: vec![],
-                build: vec![],
-            }
+            Version::new(6, 3, 0)
         );
     }
 }


### PR DESCRIPTION
Bump semver to the latest release with minor code changes to how Version instances are created.
This is basically the same as #630 but with the necessary changes that dependabot can't do on its
own.