### PR TITLE
Fix warning 'panic message is not a string literal'

### DIFF
--- a/src/producer.rs
+++ b/src/producer.rs
@@ -1559,7 +1559,7 @@ mod tests {
             reader.read_to_end(&mut json).unwrap();
             assert_eq!(json, mapping);
         } else {
-            assert!(false, format!("Failed to read the file: {}", json_path));
+            assert!(false, "Failed to read the file: {}", json_path);
         }
 
         check_produced(tmp_path, &receiver, expected);


### PR DESCRIPTION
This is a new warning introduced with recent versions of the Rust compiler. It warns that this use of the `panic!` macro will not be compatible with the upcoming _Rust 2021 edition_.