### PR TITLE
Use the Visual Studio 2019 image in appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2017
+image: Visual Studio 2019
 platform:
 - x64
 


### PR DESCRIPTION
Just trying to see whether bumping up the AppVeyor image to the latest version may fix the compile errors for builds with nightly.﻿