### PR TITLE
Remove remaining pre-2018 edition code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
         name: clippy
         language: system
         types: [file, rust]
-        entry: cargo clippy --bins --tests --examples --all # -- -D warnings # Use -D warnings option to ensure the job fails when encountering warnings
+        entry: cargo clippy --bins --tests --examples --all -- -D rust_2018_idioms # -- -D warnings # Use -D warnings option to ensure the job fails when encountering warnings
         pass_filenames: false
 
       - id: test

--- a/src/cobertura.rs
+++ b/src/cobertura.rs
@@ -555,7 +555,6 @@ fn write_lines(writer: &mut Writer<Cursor<Vec<u8>>>, lines: &[Line]) {
 
 #[cfg(test)]
 mod tests {
-    extern crate tempfile;
     use super::*;
     use crate::{CovResult, Function};
     use std::io::Read;

--- a/src/defs.rs
+++ b/src/defs.rs
@@ -126,7 +126,7 @@ pub enum StringOrRef<'a> {
 }
 
 impl<'a> Display for StringOrRef<'a> {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             StringOrRef::S(s) => write!(f, "{}", s),
             StringOrRef::R(s) => write!(f, "{}", s),

--- a/src/gcov.rs
+++ b/src/gcov.rs
@@ -1,3 +1,4 @@
+use lazy_static::lazy_static;
 use semver::Version;
 use std::env;
 use std::fmt;
@@ -11,7 +12,7 @@ pub enum GcovError {
 }
 
 impl fmt::Display for GcovError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             GcovError::ProcessFailure => write!(f, "Failed to execute gcov process"),
             GcovError::Failure((ref path, ref stdout, ref stderr)) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,24 +1,6 @@
 #![recursion_limit = "1024"]
+#![deny(rust_2018_idioms, clippy::all)]
 #![allow(clippy::too_many_arguments)]
-
-extern crate cargo_binutils;
-extern crate chrono;
-extern crate crossbeam;
-extern crate fomat_macros;
-extern crate globset;
-#[macro_use]
-extern crate lazy_static;
-extern crate log;
-extern crate quick_xml as xml;
-extern crate rustc_hash;
-extern crate semver;
-extern crate serde_derive;
-extern crate serde_json;
-extern crate smallvec;
-extern crate tempfile;
-extern crate uuid;
-extern crate walkdir;
-extern crate zip;
 
 mod defs;
 pub use crate::defs::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![recursion_limit = "1024"]
-#![deny(rust_2018_idioms, clippy::all)]
 #![allow(clippy::too_many_arguments)]
 
 mod defs;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,8 @@
-#[cfg(feature = "tc")]
-use tcmalloc::TCMalloc;
+#![deny(rust_2018_idioms, clippy::all)]
 
-#[cfg(feature = "tc")]
+#[cfg(all(unix, feature = "tc"))]
 #[global_allocator]
-static GLOBAL: TCMalloc = TCMalloc;
-
-extern crate clap;
-extern crate crossbeam;
-extern crate grcov;
-extern crate num_cpus;
-extern crate rustc_hash;
-extern crate serde_json;
-extern crate simplelog;
-extern crate tempfile;
+static GLOBAL: tcmalloc::TCMalloc = tcmalloc::TCMalloc;
 
 use clap::{crate_authors, crate_version, App, Arg, ArgGroup};
 use crossbeam::channel::bounded;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms, clippy::all)]
-
 #[cfg(all(unix, feature = "tc"))]
 #[global_allocator]
 static GLOBAL: tcmalloc::TCMalloc = tcmalloc::TCMalloc;

--- a/src/output.rs
+++ b/src/output.rs
@@ -585,7 +585,6 @@ pub fn output_html(
 
 #[cfg(test)]
 mod tests {
-    extern crate tempfile;
     use super::*;
     use std::{collections::BTreeMap, path::Path};
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -11,8 +11,8 @@ use std::str;
 
 use log::error;
 
-use xml::events::{BytesStart, Event};
-use xml::Reader;
+use quick_xml::events::{BytesStart, Event};
+use quick_xml::Reader;
 
 use rustc_hash::FxHashMap;
 
@@ -32,10 +32,10 @@ impl From<io::Error> for ParserError {
     }
 }
 
-impl From<xml::Error> for ParserError {
-    fn from(err: xml::Error) -> ParserError {
+impl From<quick_xml::Error> for ParserError {
+    fn from(err: quick_xml::Error) -> ParserError {
         match err {
-            xml::Error::Io(e) => ParserError::Io(e),
+            quick_xml::Error::Io(e) => ParserError::Io(e),
             _ => ParserError::Parse(format!("{:?}", err)),
         }
     }
@@ -48,7 +48,7 @@ impl From<ParseIntError> for ParserError {
 }
 
 impl fmt::Display for ParserError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             ParserError::Io(ref err) => write!(f, "IO error: {}", err),
             ParserError::Parse(ref s) => write!(f, "Record containing invalid integer: '{}'", s),
@@ -516,7 +516,7 @@ pub fn parse_gcov(gcov_path: &Path) -> Result<Vec<(String, CovResult)>, ParserEr
 
 fn get_xml_attribute<R: BufRead>(
     reader: &Reader<R>,
-    event: &BytesStart,
+    event: &BytesStart<'_>,
     name: &str,
 ) -> Result<String, ParserError> {
     for a in event.attributes() {

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -1,5 +1,3 @@
-extern crate tempfile;
-
 use rustc_hash::FxHashMap;
 use std::cell::RefCell;
 use std::env;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -303,7 +303,7 @@ impl<E: Endian> GcovReader<E> for GcovReaderBuf<E> {
 }
 
 impl Display for GcovError {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             GcovError::Io(e) => write!(f, "{}", e),
             GcovError::Str(e) => write!(f, "{}", e),
@@ -312,7 +312,7 @@ impl Display for GcovError {
 }
 
 impl Debug for Gcno {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         for fun in &self.functions {
             writeln!(
                 f,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms, clippy::all)]
-
 use globset::{Glob, GlobSetBuilder};
 use regex::Regex;
 use serde_json::Value;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,8 +1,4 @@
-extern crate globset;
-extern crate regex;
-extern crate serde_json;
-extern crate walkdir;
-extern crate zip;
+#![deny(rust_2018_idioms, clippy::all)]
 
 use globset::{Glob, GlobSetBuilder};
 use regex::Regex;


### PR DESCRIPTION
Although Rust 2018 edition is defined in the Cargo.toml, there were still many code parts that used 2015 style.

Adding the `rust_2018_idioms` lint helped in identifying the remaining 2015 parts and I converted them to 2018 style. That is mostly:
- Remove `extern crate` statements.
- Add hidden lifetimes like `std::fmt::Formatter<'_>` instead of just `std::fmt::Formatter`.
- Use external macros directly without `#[macro_use]`.

In addition, I noticed that the `tcmalloc` crate doesn't compile on Windows (discovered while cross compiling from MacOS). Therefore, I further limited the `tc` feature to only work on unix platforms.