### PR TITLE
Fix all benchmarks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -213,6 +213,10 @@ script:
         export CARGO_OPTIONS="--release --features tc --target-dir tcmalloc_build";
         cargo build --verbose $CARGO_OPTIONS;
       fi
+    - |
+      if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
+        cargo build --verbose --benches
+      fi
 before_deploy:
     - tar -cvjSf grcov-${TRAVIS_OS_NAME}-x86_64.tar.bz2 -C target/release/ grcov
     - tar -cvjSf grcov-tcmalloc-${TRAVIS_OS_NAME}-x86_64.tar.bz2 -C tcmalloc_build/release/ grcov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,6 +49,10 @@ build_script:
   - cargo build %CARGO_RELEASE_ARG% --locked --target %TARGET%
   - 7z a grcov-win-%PLATFORM_TARGET%.tar .\target\%TARGET%\%BUILD_TYPE%\grcov.exe
   - 7z a grcov-win-%PLATFORM_TARGET%.tar.bz2 grcov-win-%PLATFORM_TARGET%.tar
+  - ps: |
+      If ($env:CHANNEL -eq "nightly") {
+         cargo build --locked --target %TARGET% --benches
+      }
 
 test_script:
   - set LLVM_PROFILE_FILE="grcov-%p-%m.profraw"

--- a/benches/filter.rs
+++ b/benches/filter.rs
@@ -1,6 +1,5 @@
 #![feature(test)]
-extern crate grcov;
-extern crate rustc_hash;
+#![allow(clippy::unit_arg)]
 extern crate test;
 
 use grcov::{CovResult, Function, FunctionMap};

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -1,7 +1,5 @@
 #![feature(test)]
-extern crate crossbeam;
-extern crate grcov;
-extern crate rustc_hash;
+#![allow(clippy::unit_arg)]
 extern crate test;
 
 use crossbeam::channel::unbounded;
@@ -85,7 +83,6 @@ fn bench_lib_consumer(b: &mut Bencher) {
         FxHashMap::with_capacity_and_hasher(20_000, Default::default()),
     ));
     let (sender, receiver) = unbounded();
-    let source_root = None;
     let working_dir = PathBuf::from("");
     let gcno_buf: Vec<u8> = vec![
         111, 110, 99, 103, 42, 50, 48, 52, 74, 200, 254, 66, 0, 0, 0, 1, 9, 0, 0, 0, 0, 0, 0, 0,
@@ -104,19 +101,18 @@ fn bench_lib_consumer(b: &mut Bencher) {
             let receiver = receiver.clone();
             let result_map = Arc::clone(&result_map);
             let working_dir = working_dir.clone();
-            let source_root = source_root.clone();
 
             let t = thread::Builder::new()
                 .name(format!("Consumer {}", i))
                 .spawn(move || {
                     consumer(
                         &working_dir,
-                        &source_root,
+                        None,
                         &result_map,
                         receiver,
                         false,
                         false,
-                        &None,
+                        None,
                     );
                 })
                 .unwrap();
@@ -127,7 +123,7 @@ fn bench_lib_consumer(b: &mut Bencher) {
         for _ in 0..10_000 {
             sender
                 .send(Some(WorkItem {
-                    format: ItemFormat::GCNO,
+                    format: ItemFormat::Gcno,
                     item: ItemType::Buffers(GcnoBuffers {
                         stem: "".to_string(),
                         gcno_buf: gcno_buf.clone(),

--- a/benches/output.rs
+++ b/benches/output.rs
@@ -1,6 +1,5 @@
 #![feature(test)]
-extern crate grcov;
-extern crate rustc_hash;
+#![allow(clippy::unit_arg)]
 extern crate test;
 
 use grcov::{

--- a/benches/parser.rs
+++ b/benches/parser.rs
@@ -1,5 +1,5 @@
 #![feature(test)]
-extern crate grcov;
+#![allow(clippy::unit_arg)]
 extern crate test;
 
 use std::fs::File;

--- a/benches/reader.rs
+++ b/benches/reader.rs
@@ -1,37 +1,47 @@
 #![feature(test)]
-extern crate grcov;
+#![allow(clippy::unit_arg)]
 extern crate test;
 
-use grcov::{GcovReaderBuf, GCNO};
+use grcov::{Gcno, GcovReaderBuf, LittleEndian};
 use std::path::PathBuf;
 use test::{black_box, Bencher};
 
+const LLVM_READER_GCNO: &[u8] = include_bytes!("../test/llvm/reader.gcno");
+const LLVM_READER_GCDA: &[u8] = include_bytes!("../test/llvm/reader.gcda");
+
 #[bench]
 fn bench_reader_gcno(b: &mut Bencher) {
-    let mut gcno = GCNO::new();
+    let mut gcno = Gcno::new();
     b.iter(|| {
-        let file = GcovReaderBuf::from("test/llvm/reader.gcno");
-        black_box(gcno.read(file).unwrap());
+        let file = GcovReaderBuf::<LittleEndian>::new("reader", LLVM_READER_GCNO.to_vec());
+        black_box(gcno.read_gcno(file).unwrap());
     });
 }
 
 #[bench]
 fn bench_reader_gcda(b: &mut Bencher) {
-    let mut gcno = GCNO::new();
-    gcno.read(GcovReaderBuf::from("test/llvm/reader.gcno"))
-        .unwrap();
+    let mut gcno = Gcno::new();
+    gcno.read_gcno(GcovReaderBuf::<LittleEndian>::new(
+        "reader",
+        LLVM_READER_GCNO.to_vec(),
+    ))
+    .unwrap();
 
     b.iter(|| {
-        let file = GcovReaderBuf::from("test/llvm/reader.gcda");
+        let file = GcovReaderBuf::<LittleEndian>::new("reader", LLVM_READER_GCDA.to_vec());
         black_box(gcno.read_gcda(file).unwrap());
     });
 }
 
 #[bench]
 fn bench_reader_gcno_dump(b: &mut Bencher) {
-    let mut gcno = GCNO::new();
-    gcno.read(GcovReaderBuf::from("test/llvm/reader.gcno"))
-        .unwrap();
+    let mut gcno = Gcno::new();
+    gcno.read_gcno(GcovReaderBuf::<LittleEndian>::new(
+        "reader",
+        LLVM_READER_GCNO.to_vec(),
+    ))
+    .unwrap();
+
     b.iter(|| {
         let mut output = Vec::new();
         black_box(
@@ -47,11 +57,18 @@ fn bench_reader_gcno_dump(b: &mut Bencher) {
 
 #[bench]
 fn bench_reader_gcno_gcda_dump(b: &mut Bencher) {
-    let mut gcno = GCNO::new();
-    gcno.read(GcovReaderBuf::from("test/llvm/reader.gcno"))
-        .unwrap();
-    gcno.read_gcda(GcovReaderBuf::from("test/llvm/reader.gcda"))
-        .unwrap();
+    let mut gcno = Gcno::new();
+    gcno.read_gcno(GcovReaderBuf::<LittleEndian>::new(
+        "reader",
+        LLVM_READER_GCNO.to_vec(),
+    ))
+    .unwrap();
+    gcno.read_gcda(GcovReaderBuf::<LittleEndian>::new(
+        "reader",
+        LLVM_READER_GCDA.to_vec(),
+    ))
+    .unwrap();
+
     b.iter(|| {
         let mut output = Vec::new();
         black_box(
@@ -67,20 +84,34 @@ fn bench_reader_gcno_gcda_dump(b: &mut Bencher) {
 
 #[bench]
 fn bench_reader_finalize_file(b: &mut Bencher) {
-    let mut gcno = GCNO::new();
-    gcno.read(GcovReaderBuf::from("test/llvm/file.gcno"))
-        .unwrap();
-    gcno.read_gcda(GcovReaderBuf::from("test/llvm/file.gcda"))
-        .unwrap();
+    let mut gcno = Gcno::new();
+    gcno.read_gcno(GcovReaderBuf::<LittleEndian>::new(
+        "reader",
+        LLVM_READER_GCNO.to_vec(),
+    ))
+    .unwrap();
+    gcno.read_gcda(GcovReaderBuf::<LittleEndian>::new(
+        "reader",
+        LLVM_READER_GCDA.to_vec(),
+    ))
+    .unwrap();
+
     b.iter(|| black_box(gcno.finalize(true)));
 }
 
 #[bench]
 fn bench_reader_finalize_file_branch(b: &mut Bencher) {
-    let mut gcno = GCNO::new();
-    gcno.read(GcovReaderBuf::from("test/llvm/file_branch.gcno"))
-        .unwrap();
-    gcno.read_gcda(GcovReaderBuf::from("test/llvm/file_branch.gcda"))
-        .unwrap();
+    let mut gcno = Gcno::new();
+    gcno.read_gcno(GcovReaderBuf::<LittleEndian>::new(
+        "reader",
+        LLVM_READER_GCNO.to_vec(),
+    ))
+    .unwrap();
+    gcno.read_gcda(GcovReaderBuf::<LittleEndian>::new(
+        "reader",
+        LLVM_READER_GCDA.to_vec(),
+    ))
+    .unwrap();
+
     b.iter(|| black_box(gcno.finalize(true)));
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -55,14 +55,14 @@ pub trait GcovReader<E: Endian> {
     }
 }
 
-struct LittleEndian;
+pub struct LittleEndian;
 impl Endian for LittleEndian {
     fn is_little_endian() -> bool {
         true
     }
 }
 
-struct BigEndian;
+pub struct BigEndian;
 impl Endian for BigEndian {
     fn is_little_endian() -> bool {
         false


### PR DESCRIPTION
I noticed that benchmarks currently don't compile and fixed them accordingly. Not 100% what each benchmark does so hopefully there is no difference in the benchmarks compared to what they did when they still worked.

Also, I had to make the `LittleEndian` & `BigEndian` structs public for the benchmarks. That two structs are likely helpful for the API in general as well, as the trait is exposed but until now no default implementations for it.