### PR TITLE
Replace clap with structopt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,7 +484,6 @@ version = "0.8.0"
 dependencies = [
  "cargo-binutils",
  "chrono",
- "clap",
  "crossbeam",
  "flate2",
  "fomat-macros",
@@ -505,6 +504,7 @@ dependencies = [
  "serde_json",
  "simplelog",
  "smallvec",
+ "structopt",
  "symbolic-common",
  "symbolic-demangle",
  "tcmalloc",
@@ -513,6 +513,15 @@ dependencies = [
  "uuid",
  "walkdir",
  "zip",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -792,6 +801,30 @@ dependencies = [
  "ctor",
  "diff",
  "output_vt100",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -1085,6 +1118,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "structopt"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "symbolic-common"
 version = "8.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1301,6 +1358,12 @@ checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
 dependencies = [
  "unic-common",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ globset = "^0.4"
 quick-xml = "^0.22"
 smallvec = "^1.6"
 rustc-hash = "^1.1"
-clap = "^2.33"
+structopt = "0.3.21"
 fomat-macros = "^0.3"
 chrono = { version = "^0.4", features = ["serde"] }
 log = "^0.4"

--- a/src/cobertura.rs
+++ b/src/cobertura.rs
@@ -3,6 +3,7 @@ use quick_xml::{
     Writer,
 };
 use rustc_hash::FxHashMap;
+use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{
     collections::BTreeSet,
@@ -333,17 +334,16 @@ fn get_coverage(
 }
 
 pub fn output_cobertura(
-    source_dir: &str,
+    source_dir: Option<&Path>,
     results: CovResultIter,
-    output_file: Option<&str>,
+    output_file: Option<&Path>,
     demangle: bool,
 ) {
     let demangle_options = DemangleOptions::name_only();
-    let sources = vec![match source_dir {
-        "" => ".",
-        _ => source_dir,
-    }
-    .to_string()];
+    let sources = vec![source_dir
+        .unwrap_or_else(|| Path::new("."))
+        .display()
+        .to_string()];
     let coverage = get_coverage(results, sources, demangle, demangle_options);
 
     let mut writer = Writer::new_with_indent(Cursor::new(vec![]), b' ', 4);
@@ -721,7 +721,7 @@ mod tests {
         )];
 
         let results = Box::new(results.into_iter());
-        output_cobertura("", results, Some(file_path.to_str().unwrap()), true);
+        output_cobertura(None, results, Some(&file_path), true);
 
         let results = read_file(&file_path);
 
@@ -756,7 +756,7 @@ mod tests {
         )];
 
         let results = Box::new(results.into_iter());
-        output_cobertura("", results, Some(file_path.to_str().unwrap()), true);
+        output_cobertura(None, results, Some(file_path.as_ref()), true);
 
         let results = read_file(&file_path);
 
@@ -796,7 +796,7 @@ mod tests {
         ];
 
         let results = Box::new(results.into_iter());
-        output_cobertura("", results, Some(file_path.to_str().unwrap()), true);
+        output_cobertura(None, results, Some(file_path.as_ref()), true);
 
         let results = read_file(&file_path);
 
@@ -829,7 +829,7 @@ mod tests {
         )];
 
         let results = Box::new(results.into_iter());
-        output_cobertura("", results, Some(file_path.to_str().unwrap()), true);
+        output_cobertura(None, results, Some(&file_path), true);
 
         let results = read_file(&file_path);
 
@@ -850,7 +850,7 @@ mod tests {
         )];
 
         let results = Box::new(results.into_iter());
-        output_cobertura("src", results, Some(file_path.to_str().unwrap()), true);
+        output_cobertura(Some(Path::new("src")), results, Some(&file_path), true);
 
         let results = read_file(&file_path);
 

--- a/src/path_rewriting.rs
+++ b/src/path_rewriting.rs
@@ -215,11 +215,11 @@ fn is_symbolic_link(entry: &DirEntry) -> bool {
     entry.path_is_symlink()
 }
 
-fn to_globset(dirs: &[&str]) -> GlobSet {
+fn to_globset(dirs: &[impl AsRef<str>]) -> GlobSet {
     let mut glob_builder = GlobSetBuilder::new();
 
     for dir in dirs {
-        glob_builder.add(Glob::new(dir).unwrap());
+        glob_builder.add(Glob::new(dir.as_ref()).unwrap());
     }
 
     glob_builder.build().unwrap()
@@ -231,8 +231,8 @@ pub fn rewrite_paths(
     source_dir: Option<&Path>,
     prefix_dir: Option<&Path>,
     ignore_not_existing: bool,
-    to_ignore_dirs: &[&str],
-    to_keep_dirs: &[&str],
+    to_ignore_dirs: &[impl AsRef<str>],
+    to_keep_dirs: &[impl AsRef<str>],
     filter_option: Option<bool>,
     file_filter: crate::FileFilter,
 ) -> CovResultIter {
@@ -429,8 +429,8 @@ mod tests {
             None,
             None,
             false,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -458,8 +458,8 @@ mod tests {
             None,
             Some(Path::new("/home/worker/src/workspace/")),
             false,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -487,8 +487,8 @@ mod tests {
             None,
             Some(Path::new("C:\\Users\\worker\\src\\workspace\\")),
             false,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -516,8 +516,8 @@ mod tests {
             None,
             Some(Path::new("C:/Users/worker/src/workspace/")),
             false,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -545,8 +545,8 @@ mod tests {
             None,
             Some(Path::new("C:/Users/worker/src/")),
             false,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -572,8 +572,8 @@ mod tests {
             None,
             None,
             true,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -604,8 +604,8 @@ mod tests {
             None,
             None,
             true,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -633,7 +633,7 @@ mod tests {
             None,
             false,
             &["mydir/*"],
-            &[],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -660,7 +660,7 @@ mod tests {
             None,
             false,
             &["mydir/*"],
-            &[],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -691,7 +691,7 @@ mod tests {
                 None,
                 false,
                 &ignore_dirs,
-                &[],
+                &[""; 0],
                 None,
                 Default::default(),
             );
@@ -724,7 +724,7 @@ mod tests {
                 None,
                 false,
                 &ignore_dirs,
-                &[],
+                &[""; 0],
                 None,
                 Default::default(),
             );
@@ -752,7 +752,7 @@ mod tests {
             None,
             None,
             false,
-            &[],
+            &[""; 0],
             &["mydir/*"],
             None,
             Default::default(),
@@ -810,7 +810,7 @@ mod tests {
                 None,
                 None,
                 false,
-                &[],
+                &[""; 0],
                 &keep_only_dirs,
                 None,
                 Default::default(),
@@ -843,7 +843,7 @@ mod tests {
                 None,
                 None,
                 false,
-                &[],
+                &[""; 0],
                 &keep_only_dirs,
                 None,
                 Default::default(),
@@ -928,8 +928,8 @@ mod tests {
             Some(Path::new("tests")),
             None,
             true,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             Default::default(),
         )
@@ -948,8 +948,8 @@ mod tests {
             Some(&canonicalize_path("test").unwrap()),
             None,
             true,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -976,8 +976,8 @@ mod tests {
             Some(&canonicalize_path("test").unwrap()),
             None,
             true,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -1003,8 +1003,8 @@ mod tests {
             Some(&canonicalize_path("test").unwrap()),
             None,
             false,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -1030,8 +1030,8 @@ mod tests {
             Some(&canonicalize_path("test").unwrap()),
             None,
             false,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -1058,8 +1058,8 @@ mod tests {
             Some(&canonicalize_path(".").unwrap()),
             None,
             true,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -1085,8 +1085,8 @@ mod tests {
             Some(&canonicalize_path(".").unwrap()),
             None,
             true,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -1111,8 +1111,8 @@ mod tests {
             Some(&canonicalize_path(".").unwrap()),
             None,
             true,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -1138,8 +1138,8 @@ mod tests {
             Some(&canonicalize_path(".").unwrap()),
             None,
             true,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -1168,8 +1168,8 @@ mod tests {
             Some(&canonicalize_path("tests").unwrap()),
             Some(Path::new("/home/worker/src/workspace")),
             true,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -1199,8 +1199,8 @@ mod tests {
             Some(&canonicalize_path("tests").unwrap()),
             Some(Path::new("C:\\Users\\worker\\src\\workspace")),
             true,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -1226,8 +1226,8 @@ mod tests {
             None,
             None,
             false,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -1252,8 +1252,8 @@ mod tests {
             None,
             None,
             false,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -1281,8 +1281,8 @@ mod tests {
             None,
             None,
             true,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -1311,8 +1311,8 @@ mod tests {
             None,
             None,
             true,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -1341,8 +1341,8 @@ mod tests {
             None,
             Some(Path::new("/home/worker/src/workspace")),
             true,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -1374,8 +1374,8 @@ mod tests {
             None,
             Some(Path::new("C:\\Users\\worker\\src\\workspace")),
             true,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -1403,8 +1403,8 @@ mod tests {
             None,
             Some(Path::new("C:\\Users\\worker\\src\\workspace")),
             true,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -1432,8 +1432,8 @@ mod tests {
             None,
             Some(Path::new("c:\\Users\\worker\\src\\workspace")),
             true,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -1461,8 +1461,8 @@ mod tests {
             None,
             Some(Path::new("c:\\Users\\worker\\src\\workspace")),
             true,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -1491,8 +1491,8 @@ mod tests {
             Some(&canonicalize_path("tests").unwrap()),
             Some(Path::new("/home/worker/src/workspace")),
             true,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -1521,8 +1521,8 @@ mod tests {
             Some(&canonicalize_path("tests").unwrap()),
             Some(Path::new("C:\\Users\\worker\\src\\workspace")),
             true,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             Default::default(),
         );
@@ -1548,8 +1548,8 @@ mod tests {
             None,
             None,
             false,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             Some(true),
             Default::default(),
         );
@@ -1574,8 +1574,8 @@ mod tests {
             None,
             None,
             false,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             Some(false),
             Default::default(),
         );
@@ -1635,8 +1635,8 @@ mod tests {
             Some(&canonicalize_path("test").unwrap()),
             None,
             true,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             crate::FileFilter::new(
                 Some(regex::Regex::new("excluded line").unwrap()),
@@ -1678,8 +1678,8 @@ mod tests {
             Some(&canonicalize_path("test").unwrap()),
             None,
             true,
-            &[],
-            &[],
+            &[""; 0],
+            &[""; 0],
             None,
             crate::FileFilter::new(
                 Some(regex::Regex::new("excluded line").unwrap()),


### PR DESCRIPTION
This replaces the manual setup of argument parsing through clap with structopt. It makes input handling in my opinion more simple and avoids the mismatch between argument definition and retrieval as structopt makes sure that all input parameters can be converted into the defined types.

I diffed the old help output with the new one to make sure that the differences are kept to a minimum.

While implementing the changes I potentially found a bug in regards to the `path_mapping` argument. It is defined as an argument that takes **1 or more** values, thus allowing to give multiple values at once. Later it is parsed as a **single value** only though. In this new version it correctly allows **only one** value as input.