### PR TITLE
Include 'source_dir' in cobertura report

### DIFF
--- a/src/defs.rs
+++ b/src/defs.rs
@@ -14,7 +14,7 @@ pub struct Function {
     pub executed: bool,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct CovResult {
     pub lines: BTreeMap<u32, u64>,
     pub branches: BTreeMap<u32, Vec<bool>>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -521,7 +521,7 @@ fn main() {
         "files" => output_files(iterator, output_path),
         "covdir" => output_covdir(iterator, output_path),
         "html" => output_html(iterator, output_path, num_threads, branch_enabled),
-        "cobertura" => output_cobertura(iterator, output_path, demangle),
+        "cobertura" => output_cobertura(source_dir, iterator, output_path, demangle),
         _ => panic!("{} is not a supported output type", output_type),
     };
 }


### PR DESCRIPTION
If a source_dir is specified on the command-line, then all files in the
cobertura report are specified relative to that folder. The report should
then mention that source_dir instead of '.' so that files are found for
coverage display.