### PR TITLE
Disable always failing CI tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -167,11 +167,12 @@ matrix:
         - CLANG_CXX=clang++-11
         - DEPLOY=0
 
-    - os: osx
-      rust: nightly
-      env:
-        - CLANG_CXX=clang++
-        - DEPLOY=1
+    # TODO: Currently always fails with a timeout while installing some additional software.
+    # - os: osx
+    #   rust: nightly
+    #   env:
+    #     - CLANG_CXX=clang++
+    #     - DEPLOY=1
 
     - os: linux
       rust: stable

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,9 +8,10 @@ environment:
       PLATFORM_TARGET: x86_64
       PLATFORM_VS: x64
 
-    - CHANNEL: nightly
-      PLATFORM_TARGET: x86_64
-      PLATFORM_VS: x64
+    # TODO: Currently always fails with an error about the regex crate.
+    # - CHANNEL: nightly
+    #   PLATFORM_TARGET: x86_64
+    #   PLATFORM_VS: x64
 
     # TODO: The i686 build currently doesn't work.
     # - CHANNEL: nightly


### PR DESCRIPTION
I tried several attempts at getting AppVeyor nightly builds to work but that didn't work out.
Seems there is currently no way to make it work. For MacOS there is an endlessly running installation step that times out after a while.

These tests  should be enabled again when moving to Taskcluster (or temporary GitHub Actions).

Fixes #641 