### PR TITLE
Update Documentation related to codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,9 @@ By passing `-t lcov` you could generate an lcov.info file and pass it to genhtml
 genhtml -o ./target/debug/coverage/ --show-details --highlight --ignore-errors source --legend ./target/debug/lcov.info
 ```
 
-#### Coveralls/Codecov output
+LCOV output should be used when uploading to Codecov, with the `--branch` argument for partial coverage support.
+
+#### Coveralls output
 
 Coverage can also be generated in coveralls format:
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ By passing `-t lcov` you could generate an lcov.info file and pass it to genhtml
 genhtml -o ./target/debug/coverage/ --show-details --highlight --ignore-errors source --legend ./target/debug/lcov.info
 ```
 
-LCOV output should be used when uploading to Codecov, with the `--branch` argument for partial line coverage support.
+LCOV output should be used when uploading to Codecov, with the `--branch` argument for branch coverage support.
 
 #### Coveralls output
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ By passing `-t lcov` you could generate an lcov.info file and pass it to genhtml
 genhtml -o ./target/debug/coverage/ --show-details --highlight --ignore-errors source --legend ./target/debug/lcov.info
 ```
 
-LCOV output should be used when uploading to Codecov, with the `--branch` argument for partial coverage support.
+LCOV output should be used when uploading to Codecov, with the `--branch` argument for partial line coverage support.
 
 #### Coveralls output
 


### PR DESCRIPTION
codecov works better with lcov than with coveralls format.

closes #632 