### PR TITLE
``--no-method`` option for Cobertura output

### DIFF
--- a/src/cobertura.rs
+++ b/src/cobertura.rs
@@ -486,10 +486,10 @@ pub fn output_cobertura(
             }
             lines = Box::new(lines.chain(class.lines.iter()));
             write_lines(&mut writer, lines);
+            writer
+                .write_event(Event::End(BytesEnd::borrowed(class_tag)))
+                .unwrap();
         }
-        writer
-            .write_event(Event::End(BytesEnd::borrowed(class_tag)))
-            .unwrap();
         writer
             .write_event(Event::End(BytesEnd::borrowed(classes_tag)))
             .unwrap();

--- a/src/cobertura.rs
+++ b/src/cobertura.rs
@@ -449,9 +449,9 @@ pub fn output_cobertura(
             c.push_attribute(("line-rate", stats.line_rate().to_string().as_ref()));
             c.push_attribute(("branch-rate", stats.branch_rate().to_string().as_ref()));
             c.push_attribute(("complexity", stats.complexity.to_string().as_ref()));
+            writer.write_event(Event::Start(c)).unwrap();
             let mut lines: Box<dyn Iterator<Item = &Line>> = Box::new(std::iter::empty());
             if with_method {
-                writer.write_event(Event::Start(c)).unwrap();
                 writer
                     .write_event(Event::Start(BytesStart::borrowed(
                         methods_tag,

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,6 +201,9 @@ struct Opt {
     /// No symbol demangling.
     #[structopt(long)]
     no_demangle: bool,
+
+    #[structopt(long)]
+    no_method: bool,
 }
 
 fn main() {
@@ -265,6 +268,7 @@ fn main() {
         opt.excl_br_stop,
     );
     let demangle = !opt.no_demangle;
+    let method = !opt.no_method;
 
     panic::set_hook(Box::new(|panic_info| {
         let (filename, line) = panic_info
@@ -444,6 +448,7 @@ fn main() {
             iterator,
             opt.output_path.as_deref(),
             demangle,
+            method,
         ),
     };
 }


### PR DESCRIPTION
I'm using [pycobertura](https://github.com/aconrad/pycobertura) as a code coverage diff tool, but grcov's cobertura output is not compatible with it.
pycobertura only accepet
```xml
<class><lines>...<lines><class>
```
but grcov 's cobertura output contains method infos like
```xml
<class><methods><method><lines>...<lines></method></methods></class>
``` 
This PR provide a option ``--no-method`` to generate the cobertura output without method info.