### PR TITLE
Fail if llvm-profdata is innaccessible

### DIFF
--- a/src/llvm_tools.rs
+++ b/src/llvm_tools.rs
@@ -83,8 +83,8 @@ fn get_profdata_path() -> Result<PathBuf, String> {
     let path = Tool::Profdata.path().map_err(|x| x.to_string())?;
     if !path.exists() {
         Err(String::from(
-            "We couldn't find llvm-profdata. \
-             Do you have the llvm-tools component installed?"
+            "We couldn't find llvm-profdata. Try installing the llvm-tools \
+            component with `rustup component add llvm-tools-preview`."
         ))
     } else {
         Ok(path)

--- a/src/llvm_tools.rs
+++ b/src/llvm_tools.rs
@@ -38,7 +38,8 @@ pub fn profraws_to_lcov(
         profdata_path.as_ref(),
     ];
     args.splice(2..2, profraw_paths.iter().map(PathBuf::as_ref));
-    run(&Tool::Profdata.path().unwrap(), &args)?;
+
+    let path = get_profdata_path().and_then(|p| run(&p, &args))?;
 
     let binaries = if binary_path.is_file() {
         vec![binary_path.to_owned()]
@@ -76,6 +77,18 @@ pub fn profraws_to_lcov(
     }
 
     Ok(results)
+}
+
+fn get_profdata_path() -> Result<PathBuf, String> {
+    let path = Tool::Profdata.path().map_err(|x| x.to_string())?;
+    if !path.exists() {
+        Err(String::from(
+            "We couldn't find llvm-profdata. \
+             Do you have the llvm-tools component installed?"
+        ))
+    } else {
+        Ok(path)
+    }
 }
 
 #[cfg(test)]

--- a/src/llvm_tools.rs
+++ b/src/llvm_tools.rs
@@ -39,7 +39,7 @@ pub fn profraws_to_lcov(
     ];
     args.splice(2..2, profraw_paths.iter().map(PathBuf::as_ref));
 
-    let path = get_profdata_path().and_then(|p| run(&p, &args))?;
+    get_profdata_path().and_then(|p| run(&p, &args))?;
 
     let binaries = if binary_path.is_file() {
         vec![binary_path.to_owned()]


### PR DESCRIPTION
If the toolchain is improperly set up and the requisite cargo tools are innacessible, grcov currently errors out, but with an exit code of 0. This primarily causes false successes in CI.

I've patched this fork to propogate an error (and thus return non-zero) if the path located doesn't exist.

Two questions:

+ This is a potentially breaking change, and I'm not sure how this project handles documentation - I don't see a CHANGELOG in the root. Where should this be documented?
+ This is untestable with `cargo t`. Is it a small enough change that testing isn't useful, or should I/we figure something out in the CI pipeline?

Fixes #662.