### PR TITLE
Fall back to copying file on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This is a project initiated by Mozilla to gather code coverage results on Firefo
   - [Alternative reports](#alternative-reports)
   - [Hosting HTML reports and using coverage badges](#hosting-html-reports-and-using-coverage-badges)
     - [Example](#example)
+  - [Enabling symlinks on Windows](#enabling-symlinks-on-windows)
 - [Auto-formatting](#auto-formatting)
 - [Build & Test](#build--test)
 - [Minimum requirements](#minimum-requirements)
@@ -328,6 +329,31 @@ bagdes are available as SVGs at `/badges/*svg`.
 The design of generated badges is taken from `shields.io` but may not be updated immediately if there
 is any change. Using their endpoint method is recommended if other badges from their service are
 used already.
+
+### Enabling symlinks on Windows
+
+`grcov` uses symbolic links to avoid copying files, when processing directories
+of coverage data. On Windows, by default, creating symbolic links to files
+requires Administrator privileges. (The reason is to avoid security attacks in
+applications that were designed before Windows added support for symbolic
+links.)
+
+When running on Windows `grcov` will attempt to create a symbolic link. If that
+fails then `grcov` will fall back to copying the file. Copying is less efficient
+but at least allows users to run `grcov`. `grcov` will also print a warning
+when it falls back to copying a file, advising the user either to enable the
+privilege for their account or to run as Administrator.
+
+You can enable the "Create Symbolic Links" privilege for your account so that
+you do not need to run as Administrator to use `grcov`.
+
+1. Click Start, then select "Local Group Policy Editor". Or just run
+   `gpedit.msc` to open it directly.
+1. In the navigation tree, select "Computer Configuration", "Windows Settings",
+   "Security Settings", "Local Policies".
+1. In the pane on the right, select "Create symbolic links" and double-click it.
+1. Click "Add User or Group", and add your account.
+1. Log out and then log back in.
 
 #### Example
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ pub use crate::parser::*;
 mod filter;
 pub use crate::filter::*;
 
+mod symlink;
+
 mod path_rewriting;
 pub use crate::path_rewriting::*;
 

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -3,7 +3,6 @@ use std::cell::RefCell;
 use std::env;
 use std::fs::{self, File};
 use std::io::{self, BufReader, Read};
-use std::os;
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 use zip::ZipArchive;
@@ -280,16 +279,9 @@ impl Archive {
                 // don't use a hard link here because it can fail when src and dst are not on the same device
                 let src_path = dir.join(name);
 
-                #[cfg(unix)]
-                os::unix::fs::symlink(&src_path, path).unwrap_or_else(|_| {
+                crate::symlink::symlink_file(&src_path, path).unwrap_or_else(|_| {
                     panic!("Failed to create a symlink {:?} -> {:?}", src_path, path)
                 });
-
-                #[cfg(windows)]
-                os::windows::fs::symlink_file(&src_path, path).unwrap_or_else(|_| {
-                    panic!("Failed to create a symlink {:?} -> {:?}", src_path, path)
-                });
-
                 true
             }
             ArchiveType::Plain(_) => {

--- a/src/symlink.rs
+++ b/src/symlink.rs
@@ -1,0 +1,34 @@
+use std::path::Path;
+
+#[cfg(unix)]
+pub(crate) use std::os::unix::fs::symlink as symlink_file;
+
+/// Creates a symbolic link to a file.
+///
+/// On Windows, creating a symbolic link to a file requires Administrator
+/// rights. Fall back to copying if creating the symbolic link fails.
+#[cfg(windows)]
+pub(crate) fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(
+    original: P,
+    link: Q,
+) -> std::io::Result<()> {
+    use std::sync::atomic::{AtomicBool, Ordering::SeqCst};
+
+    static HAVE_PRINTED_WARNING: AtomicBool = AtomicBool::new(false);
+
+    std::os::windows::fs::symlink_file(&original, &link)
+        .or_else(|_| {
+            let _len: u64 = std::fs::copy(&original, &link)?;
+
+            // Print a warning about symbolic links, but only once per grcov run.
+            if HAVE_PRINTED_WARNING.compare_exchange(false, true, SeqCst, SeqCst).is_ok() {
+                eprintln!(
+                    "Failed to create a symlink, but successfully copied file (as fallback).\n\
+                     This is less efficient. You can enable symlinks without elevating to Administrator.\n\
+                     See instructions at https://github.com/mozilla/grcov/blob/master/README.md#enabling-symlinks-on-windows");
+            }
+
+            Ok(())
+        }
+    )
+}


### PR DESCRIPTION
Creating a symbolic link requires administrator privileges (by default)
on Windows. This commit falls back to copying a file if creating a
symbolic link fails, on Windows.