### PR TITLE
Fix compiler warning about `;` in macro

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -79,7 +79,7 @@ macro_rules! try_next {
 
 macro_rules! try_parse_next {
     ($v:expr, $l:expr) => {
-        try_parse!(try_next!($v, $l), $l);
+        try_parse!(try_next!($v, $l), $l)
     };
 }
 


### PR DESCRIPTION
Rustc now warns about a terminal `;` in macros that are evaluated
in expression contexts. The fix is trivial -- remove the `;`.