### PR TITLE
Print correct path when cannot enter directory

### DIFF
--- a/src/producer.rs
+++ b/src/producer.rs
@@ -171,7 +171,7 @@ impl Archive {
             ArchiveType::Dir(ref dir) => {
                 for entry in WalkDir::new(&dir) {
                     let entry =
-                        entry.unwrap_or_else(|_| panic!("Failed to open directory '{:?}'.", dir));
+                        entry.unwrap_or_else(|err| panic!("Failed to open directory '{:?}'.", err));
                     let full_path = entry.path();
                     if full_path.is_file() {
                         let mut file = File::open(full_path).ok();

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -171,7 +171,7 @@ impl Archive {
             ArchiveType::Dir(ref dir) => {
                 for entry in WalkDir::new(&dir) {
                     let entry =
-                        entry.unwrap_or_else(|err| panic!("Failed to open directory '{:?}'.", err));
+                        entry.unwrap_or_else(|err| panic!("Failed to open '{}'.", err.unwrap()));
                     let full_path = entry.path();
                     if full_path.is_file() {
                         let mut file = File::open(full_path).ok();

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -170,8 +170,12 @@ impl Archive {
             }
             ArchiveType::Dir(ref dir) => {
                 for entry in WalkDir::new(&dir) {
-                    let entry =
-                        entry.unwrap_or_else(|err| panic!("Failed to open '{}'.", err.unwrap()));
+                    let entry = entry.unwrap_or_else(|err| {
+                        panic!(
+                            "Failed to open '{}'.",
+                            err.path().unwrap().to_string_lossy()
+                        )
+                    });
                     let full_path = entry.path();
                     if full_path.is_file() {
                         let mut file = File::open(full_path).ok();


### PR DESCRIPTION
In case when we have unreadable file like this one:
```sh
$ ls -lhs
total 12K
4.0K -rw-r--r-- 1 mateusz mateusz  174 Dec 21 01:38 Cargo.toml
4.0K drw------- 2 root    root    4.0K Dec 21 01:40 no_permission
4.0K drwxr-xr-x 2 mateusz mateusz 4.0K Dec 21 01:38 src
```
We receive following error:
`00:42:06 [ERROR] A panic occurred at src/producer.rs:174: Failed to open directory '"/tmp/hello/."'.`
It's not very useful because it prints parent directory which is readable.

With this PR the error looks like this:
`00:43:48 [ERROR] A panic occurred at src/producer.rs:174: Failed to open '/tmp/hello/./no_permission'.`