### PR TITLE
Add log-level flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ OPTIONS:
         --log <LOG>
             Set the file where to log (or stderr or stdout). Defaults to 'stderr' [default: stderr]
 
+        --log-level <LEVEL>
+            Set the log level. [default: ERROR]  [possible values: OFF, ERROR, WARN, INFO, DEBUG, TRACE]
+
     -o, --output-path <PATH>
             Specifies the output path
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -259,7 +259,7 @@ fn main() {
             ColorChoice::Auto,
         );
         error!(
-            "Enable to create log file: {}. Switch to stderr",
+            "Unable to create log file: {}. Switch to stderr",
             opt.log.display()
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,6 +178,14 @@ struct Opt {
     /// Set the file where to log (or stderr or stdout). Defaults to 'stderr'.
     #[structopt(long, value_name = "LOG", default_value = "stderr")]
     log: PathBuf,
+    /// Set the log level.
+    #[structopt(
+        long,
+        value_name = "LEVEL",
+        default_value = "ERROR",
+        possible_values = &["OFF", "ERROR","WARN", "INFO", "DEBUG", "TRACE"],
+    )]
+    log_level: LevelFilter,
     /// Lines in covered files containing this marker will be excluded.
     #[structopt(long, value_name = "regex")]
     excl_line: Option<Regex>,
@@ -229,23 +237,23 @@ fn main() {
 
     if opt.log == stdout {
         let _ = TermLogger::init(
-            LevelFilter::Error,
+            opt.log_level,
             Config::default(),
             TerminalMode::Stdout,
             ColorChoice::Auto,
         );
     } else if opt.log == stderr {
         let _ = TermLogger::init(
-            LevelFilter::Error,
+            opt.log_level,
             Config::default(),
             TerminalMode::Stderr,
             ColorChoice::Auto,
         );
     } else if let Ok(file) = File::create(&opt.log) {
-        let _ = WriteLogger::init(LevelFilter::Error, Config::default(), file);
+        let _ = WriteLogger::init(opt.log_level, Config::default(), file);
     } else {
         let _ = TermLogger::init(
-            LevelFilter::Error,
+            opt.log_level,
             Config::default(),
             TerminalMode::Stderr,
             ColorChoice::Auto,


### PR DESCRIPTION
- Preserve existing behavior, which was a statically defined log level of ‘ERROR’
- Add `--log-level <LEVEL>` flag to explicitly set the level filter to one of the 6 valid levels: `["OFF", "ERROR","WARN", "INFO", "DEBUG", "TRACE"]`