### PR TITLE
Log warning on failure of llvm-cov

### DIFF
--- a/src/llvm_tools.rs
+++ b/src/llvm_tools.rs
@@ -4,6 +4,7 @@ use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use log::warn;
 use walkdir::WalkDir;
 
 pub fn run(cmd: impl AsRef<OsStr>, args: &[&OsStr]) -> Result<Vec<u8>, String> {
@@ -71,8 +72,12 @@ pub fn profraws_to_lcov(
             "lcov".as_ref(),
         ];
 
-        if let Ok(result) = run(&cov_tool_path, &args) {
-            results.push(result);
+        match run(&cov_tool_path, &args) {
+            Ok(result) => results.push(result),
+            Err(err_str) => warn!(
+                "Suppressing error returned by llvm-cov tool for binary {:?}\n{}",
+                binary, err_str
+            ),
         }
     }
 


### PR DESCRIPTION
example:
```
06:21:49 [WARN] Suppressing error returned by Cov Tool for binary "./target/debug/…"
Failure while running "…/bin/llvm-cov" "export" "./target/debug/…" "--instr-profile" "/var/folders/rw/41zljw1j29j9fhbcckn0crdm0000gp/T/.tmplkPlUT/3/grcov.profdata" "--format" "lcov"
error: ./target/debug/…: Failed to load coverage: Truncated coverage data
error: Could not load coverage information
```

---

Stacked on PR https://github.com/mozilla/grcov/pull/756