### PR TITLE
Add all lines to class coverage

### DIFF
--- a/src/cobertura.rs
+++ b/src/cobertura.rs
@@ -241,8 +241,6 @@ fn get_coverage(
         .map(|(_, rel_path, result)| {
             let all_lines: Vec<u32> = result.lines.iter().map(|(k, _)| k).cloned().collect();
 
-            let mut orphan_lines: BTreeSet<u32> = all_lines.iter().cloned().collect();
-
             let end: u32 = result.lines.keys().last().unwrap_or(&0) + 1;
 
             let mut start_indexes: Vec<u32> = Vec::new();
@@ -295,7 +293,6 @@ fn get_coverage(
                         .filter(|&&x| x >= function.start && x < func_end)
                     {
                         lines_in_function.push(*line);
-                        orphan_lines.remove(line);
                     }
 
                     let lines: Vec<Line> = lines_in_function
@@ -311,7 +308,7 @@ fn get_coverage(
                 })
                 .collect();
 
-            let lines: Vec<Line> = orphan_lines.into_iter().map(line_from_number).collect();
+            let lines: Vec<Line> = all_lines.into_iter().map(line_from_number).collect();
             let class = Class {
                 name: rel_path
                     .file_stem()


### PR DESCRIPTION
This PR changes the cobertura report format which was introduced with #599 to always return the complete line coverage information on class level. This aligns the class level line coverage behaviour with other reporters like [cobertura itself](https://github.com/jenkinsci/cobertura-plugin/blob/master/src/test/resources/hudson/plugins/cobertura/coverage-with-data.xml#L39) (Java), [nyc/istanbul.js](https://istanbul.js.org/docs/advanced/alternative-reporters/#cobertura ) (JavaScript) or [Coverage.py](https://github.com/nedbat/coveragepy/blob/6.2/tests/gold/xml/y_xml_branch/coverage.xml#L14) (Python) and fixes the integrations into tools like GitLab (as verified by [the following example](https://gitlab.com/fh1ch/hello-inline-coverage-rust/-/merge_requests/2/diffs)).

I can also provide a follow-up MR, which adds a [GitLab coberatura example to the readme](https://github.com/mozilla/grcov/issues/468#issuecomment-823544526), if this MR goes into the right direction.

Closes #758