### PR TITLE
Add GitLab cobertura example

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ grcov provides the following output types:
 | ade              | ActiveData\-ETL format. Only useful for Mozilla projects.                 |
 | coveralls        | Generates coverage in Coveralls format.                                   |
 | coveralls+       | Like coveralls but with function level information.                       |
+| cobertura        | Generates coverage in Cobertura format.                                   |
 | files            | Output a file list of covered or uncovered source files.                  |
 | covdir           | Provides coverage in a recursive JSON format.                             |
 | html             | Output a HTML coverage report, including coverage badges for your README. |

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This is a project initiated by Mozilla to gather code coverage results on Firefo
     - [LCOV output](#lcov-output)
     - [Coveralls/Codecov output](#coverallscodecov-output)
     - [grcov with Travis](#grcov-with-travis)
+    - [grcov with GitLab](#grcov-with-gitlab)
   - [Alternative reports](#alternative-reports)
   - [Hosting HTML reports and using coverage badges](#hosting-html-reports-and-using-coverage-badges)
     - [Example](#example)
@@ -300,6 +301,28 @@ script:
       zip -0 ccov.zip `find . \( -name "YOUR_PROJECT_NAME*.gc*" \) -print`;
       ./grcov ccov.zip -s . -t lcov --llvm --branch --ignore-not-existing --ignore "/*" -o lcov.info;
       bash <(curl -s https://codecov.io/bash) -f lcov.info;
+```
+
+#### grcov with GitLab
+
+Here is an example of a `.gitlab-ci.yml` file for source-based coverage, using
+GitLab's [test coverage visualization feature](https://docs.gitlab.com/ee/user/project/merge_requests/test_coverage_visualization.html):
+
+```yaml
+test:
+  image: rust:latest
+  variables:
+    RUSTC_BOOTSTRAP: 1
+    RUSTFLAGS: -Zinstrument-coverage
+  script:
+    - rustup component add llvm-tools-preview
+    - curl -sSL https://github.com/mozilla/grcov/releases/latest/download/grcov-v0.8.6-x86_64-unknown-linux-gnu.tar.gz | tar -xz
+    - cargo build --verbose
+    - LLVM_PROFILE_FILE="your_name-%p-%m.profraw" cargo test --verbose
+    - ./grcov . --binary-path ./target/debug/ -s . -t cobertura --branch --ignore-not-existing --ignore "/*" -o coverage.xml
+  artifacts:
+    reports:
+      cobertura: coverage.xml
 ```
 
 ### Alternative reports

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Here is an example of .travis.yml file for source-based coverage:
 language: rust
 
 before_install:
-  - curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-linux-x86_64.tar.bz2 | tar jxf -
+  - curl -L https://github.com/mozilla/grcov/releases/download/v0.8.6/grcov-v0.8.6-x86_64-unknown-linux-gnu.tar.gz | tar -xz
 
 matrix:
   include:
@@ -284,7 +284,7 @@ Here is an example of .travis.yml file:
 language: rust
 
 before_install:
-  - curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-linux-x86_64.tar.bz2 | tar jxf -
+  - curl -L https://github.com/mozilla/grcov/releases/download/v0.8.6/grcov-v0.8.6-x86_64-unknown-linux-gnu.tar.gz | tar -xz
 
 matrix:
   include:


### PR DESCRIPTION
Based on https://github.com/mozilla/grcov/pull/759#issuecomment-1027354461.

This MR adds a new grcov usage example with GitLab's [test coverage visualization feature](https://docs.gitlab.com/ee/user/project/merge_requests/test_coverage_visualization.html) using the `cobertura`report format. Besides that, it also corrects to minor mistakes within the `README.md`:

- The `cobertura` format was not listed in the `Alternative reports` chapter, only in the man chapter.
- Last release's binaries have a different file-name format, breaking the Travis examples. Since the version number is now also present in the filename, using the `latest` release download link wouldn't work so I replaced it with the version itself.

The shown example has been validated on gitlab.com, see: https://gitlab.com/fh1ch/hello-inline-coverage-rust/-/merge_requests/1/diffs

/cc @marco-c @snue