### PR TITLE
Drop version number from release artifact names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,14 +98,14 @@ jobs:
           rm -rf target/dist
           mkdir target/dist
           cd target/${{ matrix.target }}/release
-          tar cjf ../../dist/grcov-${{ github.ref_name }}-${{ matrix.target }}.tar.bz2 grcov
+          tar cjf ../../dist/grcov-${{ matrix.target }}.tar.bz2 grcov
       - name: Package (windows)
         if: ${{ matrix.os == 'windows-latest' }}
         run: |
           if (Test-Path target/dist) { rm -Recurse -Force target/dist }
           mkdir target/dist
           cd target/${{ matrix.target }}/release
-          7z a ../../dist/grcov-${{ github.ref_name }}-${{ matrix.target }}.zip grcov.exe
+          7z a ../../dist/grcov-${{ matrix.target }}.zip grcov.exe
       - name: Upload archive
         uses: actions/upload-artifact@v2
         with:
@@ -123,7 +123,7 @@ jobs:
           set -x
           for dir in $(pwd)/artifact-*; do
             cd $dir
-            sha256sum -b * >> ~/checksums-${{ github.ref_name }}.sha256
+            sha256sum -b * >> ~/checksums.sha256
           done
       - name: Create release
         id: release
@@ -147,7 +147,7 @@ jobs:
       - name: Upload artifacts
         run: |
           set -x
-          for file in $(ls artifact-*/*.{tar.bz2,zip}) ~/checksums-${{ github.ref_name }}.sha256; do
+          for file in $(ls artifact-*/*.{tar.bz2,zip}) ~/checksums.sha256; do
             filename=$(basename -- "$file")
             extension="${filename#*.}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
           rm -rf target/dist
           mkdir target/dist
           cd target/${{ matrix.target }}/release
-          tar czf ../../dist/grcov-${{ github.ref_name }}-${{ matrix.target }}.tar.gz grcov
+          tar cjf ../../dist/grcov-${{ github.ref_name }}-${{ matrix.target }}.tar.bz2 grcov
       - name: Package (windows)
         if: ${{ matrix.os == 'windows-latest' }}
         run: |
@@ -147,7 +147,7 @@ jobs:
       - name: Upload artifacts
         run: |
           set -x
-          for file in $(ls artifact-*/*.{tar.gz,zip}) ~/checksums-${{ github.ref_name }}.sha256; do
+          for file in $(ls artifact-*/*.{tar.bz2,zip}) ~/checksums-${{ github.ref_name }}.sha256; do
             filename=$(basename -- "$file")
             extension="${filename#*.}"
 
@@ -156,8 +156,8 @@ jobs:
               zip)
                 type="application/zip"
                 ;;
-              tar.gz)
-                type="application/gzip"
+              tar.bz2)
+                type="application/x-bzip2"
                 ;;
             esac
 

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Here is an example of .travis.yml file for source-based coverage:
 language: rust
 
 before_install:
-  - curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-v0.8.6-x86_64-unknown-linux-gnu.tar.gz | tar xzf -
+  - curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf -
 
 matrix:
   include:
@@ -283,7 +283,7 @@ Here is an example of .travis.yml file:
 language: rust
 
 before_install:
-  - curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-v0.8.6-x86_64-unknown-linux-gnu.tar.gz | tar xzf -
+  - curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf -
 
 matrix:
   include:


### PR DESCRIPTION
This pull request does:
* Drop the `{{ github.ref_name }}` from generated archives.
* Revert to `bzip2` compression for linux as used in earlier releases. It's slower but usually has better compression, which might be desirable for an artifact that is often requested.
* Fixup the `/latest/` release links in `README.md`

This fixes #774.

<details>
<summary>
Size comparison for the current v0.8.6 linux binary (bzip2 vs gzip)
</summary>

 ```
$ stat grcov-v0.8.6-x86_64-unknown-linux-gnu.tar.*
  File: grcov-v0.8.6-x86_64-unknown-linux-gnu.tar.bz2
  Size: 2278630   	Blocks: 4456       IO Block: 4096   regular file
  ...
  File: grcov-v0.8.6-x86_64-unknown-linux-gnu.tar.gz
  Size: 2461102   	Blocks: 4808       IO Block: 4096   regular file
```
Just about 8% size reduction.
</details>

Disclaimer: I do not have experience with GitHub Actions and did not test this further. But the changes looked straight forward enough to give it a shot.