### PR TITLE
Add cobertura output option to the table in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ grcov provides the following output types:
 | files            | Output a file list of covered or uncovered source files.                  |
 | covdir           | Provides coverage in a recursive JSON format.                             |
 | html             | Output a HTML coverage report, including coverage badges for your README. |
+| cobertura        | Cobertura XML. Used for coverage analysis in some IDEs and Gitlab CI.     |
 
 ### Hosting HTML reports and using coverage badges
 


### PR DESCRIPTION
This was missing and sent me on a bit of a wild goose chase until I noticed it was in the man page.

I couldn't find contributing guidelines, so let me know if there are extra rules to follow for PRs. Happy to bikeshed the wording.