### PR TITLE
WIP: Make the HTML report more accessible

### DIFF
--- a/src/templates/file.html
+++ b/src/templates/file.html
@@ -5,6 +5,7 @@
 
 {% block content -%}
     {{ macros::summary(parents=parents, stats=stats) }}
+    <div role="table" aria-label="Coverage report">
     {%- for item in items -%}
         {%- if item.1 > 0 -%}
             {%- set highlight = "success" -%}
@@ -34,5 +35,6 @@
             </div>
         </div>
     {%- endfor -%}
+    </div>
 {% endblock content -%}
 

--- a/src/templates/file.html
+++ b/src/templates/file.html
@@ -11,14 +11,17 @@
             {%- set highlight = "success" -%}
             {%- set highlight_light = "success-light" -%}
             {%- set count = item.1 -%}
+            {%- set aria_label = count -%}
         {%- elif item.1 < 0 -%}
             {% set highlight = "white" -%}
             {% set highlight_light = "white" -%}
             {% set count = "" -%}
+            {%- set aria_label = "no coverage" -%}
         {%- else -%}
             {%- set highlight = "danger" -%}
             {%- set highlight_light = "danger-light" -%}
             {%- set count = "" -%}
+            {%- set aria_label = "0" -%}
         {%- endif -%}
         <div class="columns p-0 m-0" role="row">
             <div
@@ -29,7 +32,7 @@
             </div>
             <div
                 class="column is-1 is-narrow p-0 has-text-centered has-text-{{ highlight_light }} has-background-{{ highlight }}"
-                role="cell">
+                role="cell" aria-label="{{ aria_label }}">
                 {{ count }}
             </div>
             <div class="column has-background-{{ highlight_light }} p-0"

--- a/src/templates/file.html
+++ b/src/templates/file.html
@@ -23,14 +23,17 @@
         <div class="columns p-0 m-0" role="row">
             <div
                 class="column is-1 is-narrow p-0 has-text-centered"
-                id="{{ item.0 }}">
+                id="{{ item.0 }}"
+                role="cell">
                 <a href="#{{ item.0 }}">{{ item.0 }}</a>
             </div>
             <div
-                class="column is-1 is-narrow p-0 has-text-centered has-text-{{ highlight_light }} has-background-{{ highlight }}">
+                class="column is-1 is-narrow p-0 has-text-centered has-text-{{ highlight_light }} has-background-{{ highlight }}"
+                role="cell">
                 {{ count }}
             </div>
-            <div class="column has-background-{{ highlight_light }} p-0">
+            <div class="column has-background-{{ highlight_light }} p-0"
+                 role="cell">
                 <pre class="has-background-{{ highlight_light }} py-0 px-2">{{ item.2 }}</pre>
             </div>
         </div>

--- a/src/templates/file.html
+++ b/src/templates/file.html
@@ -20,7 +20,7 @@
             {%- set highlight_light = "danger-light" -%}
             {%- set count = "" -%}
         {%- endif -%}
-        <div class="columns p-0 m-0">
+        <div class="columns p-0 m-0" role="row">
             <div
                 class="column is-1 is-narrow p-0 has-text-centered"
                 id="{{ item.0 }}">


### PR DESCRIPTION
We are using grcov for the [accessibility infrastructure modules in GNOME](https://gitlab.gnome.org/GNOME/at-spi2-core).  I'm starting this PR to make the generated HTML report easier to navigate for people who use screen readers.

Grcov's per-file reports indicate line coverage by color-coding and showing the number of times each line got executed, so they are easy to scan quickly by sighted users.  Each line has the line number, the coverage info, and the source code; the HTML for each line is a `<div>` with other `<div>`s for each column.

For users of screen readers, I've started with a few changes for navigation:

* Wrap all the lines in a `<div role="table">`.  This makes screen readers aware that this has tabular structure, and makes the line report easy to navigate to.  It also gives users a hint of how to navigate within the report.
* Give each line's `<div>` a `role="row"`, since it is now part of a table.
* Give each column a `role="cell"`.

With the above, each logical cell can be navigated using a screen reader's usual hotkeys for tables.

Next, to allow fast scanning, give the coverage column an `aria-label` with values as follows:

* `"no coverage"` - lines that are not executable.  Is this too long a string?  Screen readers allow interruption if you move to the next row before it finishes saying "no coverage", but I'm open to suggestions.
* `"0"` - lines that did not get executed - the ones to watch for, presumably.
* `"some-number"` - the actual number of times the line got executed.

One thing I'm not sure about - should the aria-label also have an indication of what the number means?  I.e. `aria-label="0 times"` instead of `aria-label="0"`?  The whole table does not have column headings; would that be better / less verbose instead?

I have not tweaked the `index.html` summary template.  That one is already a `<table>`, thankfully, but I wonder if the labels could be better: `42 out of 45 lines covered" instead of `42 / 45` for screen readers, for example.  I'm not sure.

Maybe the progress bars in the second column should be hidden for screen readers?  They only duplicate the numerical information from the third column.