### PR TITLE
Add markdown output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 
 [[package]]
+name = "bytecount"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,6 +498,7 @@ dependencies = [
  "structopt",
  "symbolic-common",
  "symbolic-demangle",
+ "tabled",
  "tcmalloc",
  "tempfile",
  "tera",
@@ -508,6 +515,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -732,6 +745,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "papergrid"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453cf71f2a37af495a1a124bf30d4d7469cfbea58e9f2479be9d222396a518a2"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1159,7 +1183,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -1212,6 +1236,30 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "tabled"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5b2f8c37d26d87d2252187b0a45ea3cbf42baca10377c7e7eaaa2800fa9bf97"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+ "unicode-width",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9ee618502f497abf593e1c5c9577f34775b111480009ffccd7ad70d23fcaba8"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ smallvec = "1.10"
 structopt = "0.3.26"
 symbolic-common = "9.2"
 symbolic-demangle = { version = "9.2", default-features = false }
+tabled = "0.8"
 tempfile = "3.3"
 tera = "1.17"
 uuid = { version = "1.2", features = ["v4"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ enum OutputType {
     Covdir,
     Html,
     Cobertura,
+    Markdown,
 }
 
 impl FromStr for OutputType {
@@ -43,6 +44,7 @@ impl FromStr for OutputType {
             "covdir" => Self::Covdir,
             "html" => Self::Html,
             "cobertura" => Self::Cobertura,
+            "markdown" => Self::Markdown,
             _ => return Err(format!("{} is not a supported output type", s)),
         })
     }
@@ -90,6 +92,7 @@ struct Opt {
             - *coveralls+* for the Coveralls specific format with function information;\n\
             - *ade* for the ActiveData-ETL specific format;\n\
             - *files* to only return a list of files.\n\
+            - *markdown* for human easy read.\n\
         ",
         value_name = "OUTPUT TYPE",
         default_value = "lcov",
@@ -106,6 +109,7 @@ struct Opt {
             "covdir",
             "html",
             "cobertura",
+            "markdown",
         ],
     )]
     output_type: OutputType,
@@ -457,5 +461,6 @@ fn main() {
             opt.output_path.as_deref(),
             demangle,
         ),
+        OutputType::Markdown => output_markdown(iterator, opt.output_path.as_deref()),
     };
 }


### PR DESCRIPTION
This PR add a new markdown output. This is related to https://github.com/mozilla/grcov/issues/498.

Example output:

## RAW
```
| file          | coverage | covered | missed_lines |
|---------------|----------|---------|--------------|
| foo/bar/a.cpp | 100%     | 2 / 2   |              |
| foo/bar/b.cpp | 40%      | 2 / 5   | 1, 5-7       |

Total coverage: 57%
```

## Markdown parsed

| file          | coverage | covered | missed_lines |
|---------------|----------|---------|--------------|
| foo/bar/a.cpp | 100%     | 2 / 2   |              |
| foo/bar/b.cpp | 40%      | 2 / 5   | 1, 5-7       |

Total coverage: 57%