### PR TITLE
Replace infer with file-format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,17 +179,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
-name = "cfb"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
-dependencies = [
- "byteorder",
- "fnv",
- "uuid",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,6 +404,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "file-format"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93c402c8ea324841763c7009b70cd3e88c56ab2c6a8b1d9a1c88f333d8fb6003"
+
+[[package]]
 name = "flate2"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,9 +484,9 @@ dependencies = [
  "cargo-binutils",
  "chrono",
  "crossbeam-channel",
+ "file-format",
  "flate2",
  "globset",
- "infer",
  "lazy_static",
  "log",
  "md-5",
@@ -579,15 +574,6 @@ dependencies = [
  "thread_local",
  "walkdir",
  "winapi-util",
-]
-
-[[package]]
-name = "infer"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6c16b11a665b26aeeb9b1d7f954cdeb034be38dd00adab4f2ae921a8fee804"
-dependencies = [
- "cfb",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ demangle-with-swift = [
 cargo-binutils = "0.3"
 chrono = { version = "0.4", features = ["serde"] }
 crossbeam-channel = "0.5"
-file-format = "0.10.0"
+file-format = "0.11.0"
 flate2 = "1.0"
 globset = "0.4"
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,9 @@ demangle-with-swift = [
 cargo-binutils = "0.3"
 chrono = { version = "0.4", features = ["serde"] }
 crossbeam-channel = "0.5"
+file-format = "0.10.0"
 flate2 = "1.0"
 globset = "0.4"
-infer = "0.11.0"
 lazy_static = "1.4"
 log = "0.4"
 md-5 = "0.10"


### PR DESCRIPTION
Pros of `file-format` against `infer`:

- Support for many more formats
- Support for formats based on **MS-DOS Executable** more accurate.
- Enum-based API
- Zero-dependency