### PR TITLE
Make html branch info dependent on cmdline argument --branch

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -11,7 +11,9 @@
                 <th>{{ kind }}</th>
                 <th class="has-text-centered" colspan="3">Line Coverage</th>
                 <th class="has-text-centered" colspan="2">Functions</th>
-                <th class="has-text-centered" colspan="2">Branches</th>
+                {% if branch_enabled %}
+                    <th class="has-text-centered" colspan="2">Branches</th>
+                {% endif %}
             </tr>
         </thead>
         <tbody>

--- a/src/templates/macros.html
+++ b/src/templates/macros.html
@@ -21,7 +21,9 @@
     <nav class="level">
         {{ self::summary_line(kind="lines", covered=stats.covered_lines, total=stats.total_lines, precision=precision) }}
         {{ self::summary_line(kind="functions", covered=stats.covered_funs, total=stats.total_funs, precision=precision) }}
-        {{ self::summary_line(kind="branches", covered=stats.covered_branches, total=stats.total_branches, precision=precision) }}
+        {% if branch_enabled %}
+	    {{ self::summary_line(kind="branches", covered=stats.covered_branches, total=stats.total_branches, precision=precision) }}
+	{% endif %}
     </nav>
 {% endmacro %}
 
@@ -30,8 +32,10 @@
     {%- set lines_sev = lines_per | severity(kind="lines") -%}
     {%- set functions_per = percent(num=stats.covered_funs, den=stats.total_funs) -%}
     {%- set functions_sev = functions_per | severity(kind="functions") -%}
-    {%- set branches_per = percent(num=stats.covered_branches, den=stats.total_branches) -%}
-    {%- set branches_sev = branches_per | severity(kind="branches") -%}
+    {% if branch_enabled %}
+        {%- set branches_per = percent(num=stats.covered_branches, den=stats.total_branches) -%}
+        {%- set branches_sev = branches_per | severity(kind="branches") -%}
+    {% endif %}
     <tr>
         <th><a href="{{ url }}">{{ name }}</a></th>
         <!-- -->
@@ -53,7 +57,9 @@
         <td class="has-text-centered has-background-{{ functions_sev }} p-2">{{ functions_per | round(precision=precision) }}%</td>
         <td class="has-text-centered has-background-{{ functions_sev }} p-2">{{ stats.covered_funs }} / {{ stats.total_funs }} </td>
         <!-- -->
-        <td class="has-text-centered has-background-{{ branches_sev }} p-2">{{ branches_per | round(precision=precision) }}%</td>
-        <td class="has-text-centered has-background-{{ branches_sev }} p-2">{{ stats.covered_branches }} / {{ stats.total_branches }}</td>
+        {% if branch_enabled %}
+            <td class="has-text-centered has-background-{{ branches_sev }} p-2">{{ branches_per | round(precision=precision) }}%</td>
+            <td class="has-text-centered has-background-{{ branches_sev }} p-2">{{ stats.covered_branches }} / {{ stats.total_branches }}</td>
+        {% endif %}
     </tr>
 {% endmacro %}


### PR DESCRIPTION
Currently if the command line option `--branch` is not passed, when generating html reports (`-t html`), the report still shows 100% all green in the _Branches_ html table column. Like on the screenshot below.

![image](https://user-images.githubusercontent.com/3736314/223761629-e4702166-efa4-428c-be50-3468155207d6.png)

I believe that the html report should take the command line argument `--branch` into consideration, and not show any _Branches_ column in the report, if the variable is not passed.
So the current PR addresses this by modifying the `tera` templates to reuse the already existing `branch_enabled` variable inserted into the context. 

1. If the `--branch` is **not** passed, then the report will look like:
![image](https://user-images.githubusercontent.com/3736314/223760938-ff9514c3-76f4-4d99-b45a-6410e5aa79a3.png)

2. if the `--branch` is passed, then the report will look like (given that the tests were compiled with branching information i.e. GCC `-coverage` or older `-fprofile-arcs`):
![image](https://user-images.githubusercontent.com/3736314/223764004-9433f84e-44ce-48da-bcba-9e5339ad5f26.png)
