### PR TITLE
Fix clippy linting

### DIFF
--- a/src/cobertura.rs
+++ b/src/cobertura.rs
@@ -237,7 +237,7 @@ fn get_coverage(
     let packages: Vec<Package> = results
         .iter()
         .map(|(_, rel_path, result)| {
-            let all_lines: Vec<u32> = result.lines.iter().map(|(k, _)| k).cloned().collect();
+            let all_lines: Vec<u32> = result.lines.keys().cloned().collect();
 
             let end: u32 = result.lines.keys().last().unwrap_or(&0) + 1;
 

--- a/src/gcov.rs
+++ b/src/gcov.rs
@@ -37,7 +37,7 @@ pub fn run_gcov(
     branch_enabled: bool,
     working_dir: &Path,
 ) -> Result<(), GcovError> {
-    let mut command = Command::new(&get_gcov());
+    let mut command = Command::new(get_gcov());
     let command = if branch_enabled {
         command.arg("-b").arg("-c")
     } else {
@@ -68,7 +68,7 @@ pub fn run_gcov(
 pub fn get_gcov_version() -> &'static Version {
     lazy_static! {
         static ref V: Version = {
-            let output = Command::new(&get_gcov())
+            let output = Command::new(get_gcov())
                 .arg("--version")
                 .output()
                 .expect("Failed to execute `gcov`. `gcov` is required (it is part of GCC).");

--- a/src/html.rs
+++ b/src/html.rs
@@ -316,7 +316,7 @@ pub fn gen_dir_index(
     branch_enabled: bool,
 ) {
     let index = Path::new(dir_name).join("index.html");
-    let output_file = output.join(&index);
+    let output_file = output.join(index);
     create_parent(&output_file);
     let mut output = match File::create(&output_file) {
         Err(_) => {

--- a/src/llvm_tools.rs
+++ b/src/llvm_tools.rs
@@ -94,7 +94,7 @@ pub fn profraws_to_lcov(
         a
     });
 
-    get_profdata_path().and_then(|p| run_with_stdin(&p, &stdin_paths, &args))?;
+    get_profdata_path().and_then(|p| run_with_stdin(p, &stdin_paths, &args))?;
 
     let metadata = fs::metadata(binary_path)
         .unwrap_or_else(|e| panic!("Failed to open directory '{:?}': {:?}.", binary_path, e));
@@ -188,13 +188,13 @@ mod tests {
 
         fs::copy(
             PathBuf::from("tests/rust/Cargo.toml"),
-            &tmp_path.join("Cargo.toml"),
+            tmp_path.join("Cargo.toml"),
         )
         .expect("Failed to copy file");
-        fs::create_dir(&tmp_path.join("src")).expect("Failed to create dir");
+        fs::create_dir(tmp_path.join("src")).expect("Failed to create dir");
         fs::copy(
             PathBuf::from("tests/rust/src/main.rs"),
-            &tmp_path.join("src/main.rs"),
+            tmp_path.join("src/main.rs"),
         )
         .expect("Failed to copy file");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -351,9 +351,7 @@ fn main() {
     let source_root = opt
         .source_dir
         .filter(|source_dir| source_dir != Path::new(""))
-        .map(|source_dir| {
-            canonicalize_path(&source_dir).expect("Source directory does not exist.")
-        });
+        .map(|source_dir| canonicalize_path(source_dir).expect("Source directory does not exist."));
 
     let prefix_dir = opt.prefix_dir.or_else(|| source_root.clone());
 
@@ -474,6 +472,9 @@ fn main() {
     let output_path = match output_types.len() {
         0 => return,
         1 => opt.output_path.as_deref(),
+        //TODO: Remove this #[allow()] which is a false positive clippy warning
+        //      see issue https://github.com/mozilla/grcov/issues/980
+        #[allow(clippy::manual_filter)]
         _ => match opt.output_path.as_deref() {
             Some(output_path) => {
                 if output_path.is_dir() {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -117,7 +117,7 @@ fn read_expected(
             }
         }
     };
-    read_file(&path.join(&name))
+    read_file(&path.join(name))
 }
 
 /// Returns the path to grcov executable.


### PR DESCRIPTION
Fixes failed checks in many PRs for example https://github.com/mozilla/grcov/actions/runs/4345920963/jobs/7591298097

- fix all https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
- fix all https://rust-lang.github.io/rust-clippy/master/index.html#iter_kv_map
- allow https://rust-lang.github.io/rust-clippy/master/index.html#manual_filter since it's a false positive that is already fixed upstrean and will be  present on next clippy release