### PR TITLE
Add precision cmdline arg

### DIFF
--- a/src/covdir.rs
+++ b/src/covdir.rs
@@ -4,13 +4,13 @@ use std::collections::BTreeMap;
 pub use crate::defs::*;
 
 impl CDStats {
-    pub fn new(total: usize, covered: usize) -> Self {
+    pub fn new(total: usize, covered: usize, precision: usize) -> Self {
         let missed = total - covered;
         Self {
             total,
             covered,
             missed,
-            percent: Self::get_percent(covered, total),
+            percent: Self::get_percent(covered, total, precision),
         }
     }
 
@@ -23,13 +23,20 @@ impl CDStats {
         self.missed += other.missed;
     }
 
-    pub fn set_percent(&mut self) {
-        self.percent = Self::get_percent(self.covered, self.total);
+    pub fn set_percent(&mut self, precision: usize) {
+        self.percent = Self::get_percent(self.covered, self.total, precision);
     }
 
-    pub fn get_percent(x: usize, y: usize) -> f64 {
+    pub fn get_percent(x: usize, y: usize, precision: usize) -> f64 {
         if y != 0 {
-            f64::round(x as f64 / (y as f64) * 10_000.) / 100.
+            // This function calculates the coverage percentage with rounded decimal points up to `precision`.
+            // However the `serdes_json` will determine the final format of `coveragePercent` in the report.
+            // If `precision` is 0, then `coveragePercent` output will still have 1 (null) decimal place, i.e. 98.321... -> 98.0.
+            // If `coveragePercent` has multiple trailing zeros, they will be truncated to 1 decimal place i.e 98.0000... -> 98.0.
+            // These limitation are considered good enough behavior for covdir report, for an improved output
+            // a custom serdes_json serializer for `f64` would have to be written.
+            f64::round(x as f64 / (y as f64) * f64::powi(10.0, precision as i32 + 2))
+                / f64::powi(10.0, precision as i32)
         } else {
             0.0
         }
@@ -37,11 +44,11 @@ impl CDStats {
 }
 
 impl CDFileStats {
-    pub fn new(name: String, coverage: BTreeMap<u32, u64>) -> Self {
+    pub fn new(name: String, coverage: BTreeMap<u32, u64>, precision: usize) -> Self {
         let (total, covered, lines) = Self::get_coverage(coverage);
         Self {
             name,
-            stats: CDStats::new(total, covered),
+            stats: CDStats::new(total, covered, precision),
             coverage: lines,
         }
     }
@@ -83,16 +90,16 @@ impl CDDirStats {
         }
     }
 
-    pub fn set_stats(&mut self) {
+    pub fn set_stats(&mut self, precision: usize) {
         for file in self.files.iter() {
             self.stats.add(&file.stats);
         }
         for dir in self.dirs.iter() {
             let mut dir = dir.borrow_mut();
-            dir.set_stats();
+            dir.set_stats(precision);
             self.stats.add(&dir.stats);
         }
-        self.stats.set_percent();
+        self.stats.set_percent(precision);
     }
 
     pub fn into_json(self) -> serde_json::Value {

--- a/src/main.rs
+++ b/src/main.rs
@@ -532,6 +532,7 @@ fn main() {
                 num_threads,
                 opt.branch,
                 opt.output_config_file.as_deref(),
+                opt.precision,
             ),
             OutputType::Cobertura => output_cobertura(
                 source_root.as_deref(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -222,7 +222,7 @@ struct Opt {
     threads: Option<usize>,
     /// Sets coverage decimal point precision on output reports.
     #[structopt(long, value_name = "NUMBER", default_value = "2")]
-    _precision: usize,
+    precision: usize,
     #[structopt(long = "guess-directory-when-missing")]
     guess_directory: bool,
     /// Set the branch for coveralls report. Defaults to 'master'.
@@ -539,7 +539,9 @@ fn main() {
                 output_path.as_deref(),
                 demangle,
             ),
-            OutputType::Markdown => output_markdown(&iterator, output_path.as_deref()),
+            OutputType::Markdown => {
+                output_markdown(&iterator, output_path.as_deref(), opt.precision)
+            }
         };
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -525,7 +525,7 @@ fn main() {
                 demangle,
             ),
             OutputType::Files => output_files(&iterator, output_path.as_deref()),
-            OutputType::Covdir => output_covdir(&iterator, output_path.as_deref()),
+            OutputType::Covdir => output_covdir(&iterator, output_path.as_deref(), opt.precision),
             OutputType::Html => output_html(
                 &iterator,
                 output_path.as_deref(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,6 +220,9 @@ struct Opt {
     parallel: bool,
     #[structopt(long, value_name = "NUMBER")]
     threads: Option<usize>,
+    /// Sets coverage decimal point precision on output reports.
+    #[structopt(long, value_name = "NUMBER", default_value = "2")]
+    _precision: usize,
     #[structopt(long = "guess-directory-when-missing")]
     guess_directory: bool,
     /// Set the branch for coveralls report. Defaults to 'master'.

--- a/src/output.rs
+++ b/src/output.rs
@@ -587,7 +587,7 @@ pub fn output_html(
     html::gen_coverage_json(&global.stats, &config, &output);
 }
 
-pub fn output_markdown(results: &[ResultTuple], output_file: Option<&Path>) {
+pub fn output_markdown(results: &[ResultTuple], output_file: Option<&Path>, precision: usize) {
     #[derive(Tabled)]
     struct LineSummary {
         file: String,
@@ -635,7 +635,10 @@ pub fn output_markdown(results: &[ResultTuple], output_file: Option<&Path>) {
         let covered: usize = result.lines.len() - missed;
         summary.push(LineSummary {
             file: rel_path.display().to_string(),
-            coverage: format!("{}%", covered * 100 / result.lines.len()),
+            coverage: format!(
+                "{:.precision$}%",
+                (covered as f32 * 100.0 / result.lines.len() as f32),
+            ),
             covered: format!("{} / {}", covered, result.lines.len()),
             missed_lines,
         });
@@ -647,8 +650,8 @@ pub fn output_markdown(results: &[ResultTuple], output_file: Option<&Path>) {
     writeln!(writer).unwrap();
     writeln!(
         writer,
-        "Total coverage: {}%",
-        total_covered * 100 / total_lines
+        "Total coverage: {:.precision$}%",
+        (total_covered as f32 * 100.0 / total_lines as f32),
     )
     .unwrap()
 }
@@ -948,15 +951,15 @@ mod tests {
             ),
         ];
 
-        output_markdown(&results, Some(&file_path));
+        output_markdown(&results, Some(&file_path), 2);
 
         let results = &read_file(&file_path);
         let expected = "| file          | coverage | covered | missed_lines |
 |---------------|----------|---------|--------------|
-| foo/bar/a.cpp | 100%     | 2 / 2   |              |
-| foo/bar/b.cpp | 40%      | 2 / 5   | 1, 5-7       |
+| foo/bar/a.cpp | 100.00%  | 2 / 2   |              |
+| foo/bar/b.cpp | 40.00%   | 2 / 5   | 1, 5-7       |
 
-Total coverage: 57%
+Total coverage: 57.14%
 ";
         assert_eq!(results, expected);
     }

--- a/src/output.rs
+++ b/src/output.rs
@@ -180,7 +180,7 @@ pub fn output_activedata_etl(results: &[ResultTuple], output_file: Option<&Path>
     }
 }
 
-pub fn output_covdir(results: &[ResultTuple], output_file: Option<&Path>) {
+pub fn output_covdir(results: &[ResultTuple], output_file: Option<&Path>, precision: usize) {
     let mut writer = BufWriter::new(get_target_output_writable(output_file));
     let mut relative: FxHashMap<PathBuf, Rc<RefCell<CDDirStats>>> = FxHashMap::default();
     let global = Rc::new(RefCell::new(CDDirStats::new("".to_string())));
@@ -227,11 +227,12 @@ pub fn output_covdir(results: &[ResultTuple], output_file: Option<&Path>) {
         prev_stats.borrow_mut().files.push(CDFileStats::new(
             path.file_name().unwrap().to_str().unwrap().to_string(),
             result.lines.clone(),
+            precision,
         ));
     }
 
     let mut global = global.take();
-    global.set_stats();
+    global.set_stats(precision);
 
     serde_json::to_writer(&mut writer, &global.into_json()).unwrap();
 }
@@ -802,7 +803,7 @@ mod tests {
             ),
         ];
 
-        output_covdir(&results, Some(&file_path));
+        output_covdir(&results, Some(&file_path), 2);
 
         let results: Value = serde_json::from_str(&read_file(&file_path)).unwrap();
         let expected_path = PathBuf::from("./test/").join(file_name);

--- a/src/output.rs
+++ b/src/output.rs
@@ -518,6 +518,7 @@ pub fn output_html(
     num_threads: usize,
     branch_enabled: bool,
     output_config_file: Option<&Path>,
+    precision: usize,
 ) {
     let output = if let Some(output_dir) = output_dir {
         PathBuf::from(output_dir)
@@ -549,7 +550,15 @@ pub fn output_html(
         let t = thread::Builder::new()
             .name(format!("Consumer HTML {}", i))
             .spawn(move || {
-                html::consumer_html(&tera, receiver, stats, &output, config, branch_enabled);
+                html::consumer_html(
+                    &tera,
+                    receiver,
+                    stats,
+                    &output,
+                    config,
+                    branch_enabled,
+                    precision,
+                );
             })
             .unwrap();
 
@@ -578,13 +587,13 @@ pub fn output_html(
 
     let global = Arc::try_unwrap(stats).unwrap().into_inner().unwrap();
 
-    html::gen_index(&tera, &global, &config, &output, branch_enabled);
+    html::gen_index(&tera, &global, &config, &output, branch_enabled, precision);
 
     for style in html::BadgeStyle::iter() {
         html::gen_badge(&tera, &global.stats, &config, &output, style);
     }
 
-    html::gen_coverage_json(&global.stats, &config, &output);
+    html::gen_coverage_json(&global.stats, &config, &output, precision);
 }
 
 pub fn output_markdown(results: &[ResultTuple], output_file: Option<&Path>, precision: usize) {

--- a/src/templates/file.html
+++ b/src/templates/file.html
@@ -4,7 +4,7 @@
 {% block title %}Grcov report - {{ current }} {% endblock title %}
 
 {% block content -%}
-    {{ macros::summary(parents=parents, stats=stats) }}
+    {{ macros::summary(parents=parents, stats=stats, precision=precision) }}
     <div role="table" aria-label="Coverage report">
     {%- for item in items -%}
         {%- if item.1 > 0 -%}

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -4,7 +4,7 @@
 {% block title %}Grcov report - {{ current }} {% endblock title %}
 
 {%- block content -%}
-    {{ macros::summary(parents=parents, stats=stats) }}
+    {{ macros::summary(parents=parents, stats=stats, precision=precision) }}
     <table class="table is-fullwidth">
         <thead>
             <tr>
@@ -17,11 +17,11 @@
         <tbody>
             {%- if kind == "Directory" -%}
                 {%- for item, info in items -%}
-                    {{ macros::stats_line(name=item, url=item~"/index.html", stats=info.stats) }}
+                    {{ macros::stats_line(name=item, url=item~"/index.html", stats=info.stats, precision=precision) }}
                 {%- endfor -%}
             {%- else -%}
                 {%- for item, info in items -%}
-                    {{ macros::stats_line(name=item, url=item~".html", stats=info.stats) }}
+                    {{ macros::stats_line(name=item, url=item~".html", stats=info.stats, precision=precision) }}
                 {%- endfor -%}
             {%- endif -%}
         </tbody>

--- a/src/templates/macros.html
+++ b/src/templates/macros.html
@@ -1,15 +1,15 @@
-{% macro summary_line(kind, covered, total) %}
+{% macro summary_line(kind, covered, total, precision) %}
     {%- set per = percent(num=covered, den=total) -%}
     <div class="level-item has-text-centered">
         <div>
             <p class="heading">{{ kind | capitalize }}</p>
             <p class="title has-text-{{ per | severity(kind=kind) }}">
-                <abbr title="{{ covered }} / {{ total }}">{{ per | round(precision=2) }} %</abbr></p>
+                <abbr title="{{ covered }} / {{ total }}">{{ per | round(precision=precision) }} %</abbr></p>
         </div>
     </div>
 {% endmacro -%}
 
-{% macro summary(parents, stats) %}
+{% macro summary(parents, stats, precision) %}
     <nav class="breadcrumb is-right" aria-label="breadcrumbs">
         <ul>
             {%- for parent in parents -%}
@@ -19,13 +19,13 @@
         </ul>
     </nav>
     <nav class="level">
-        {{ self::summary_line(kind="lines", covered=stats.covered_lines, total=stats.total_lines) }}
-        {{ self::summary_line(kind="functions", covered=stats.covered_funs, total=stats.total_funs) }}
-        {{ self::summary_line(kind="branches", covered=stats.covered_branches, total=stats.total_branches) }}
+        {{ self::summary_line(kind="lines", covered=stats.covered_lines, total=stats.total_lines, precision=precision) }}
+        {{ self::summary_line(kind="functions", covered=stats.covered_funs, total=stats.total_funs, precision=precision) }}
+        {{ self::summary_line(kind="branches", covered=stats.covered_branches, total=stats.total_branches, precision=precision) }}
     </nav>
 {% endmacro %}
 
-{% macro stats_line(name, url, stats) %}
+{% macro stats_line(name, url, stats, precision) %}
     {%- set lines_per = percent(num=stats.covered_lines, den=stats.total_lines) -%}
     {%- set lines_sev = lines_per | severity(kind="lines") -%}
     {%- set functions_per = percent(num=stats.covered_funs, den=stats.total_funs) -%}
@@ -40,20 +40,20 @@
                 class="progress is-{{ lines_sev }} is-large"
                 value="{{ lines_per }}"
                 max="100">
-                {{ lines_per | round(precision=2) }}%
+                {{ lines_per | round(precision=precision) }}%
             </progress>
         </td>
         <td class="has-text-centered has-background-{{ lines_sev }} p-2">
-            {{ lines_per | round(precision=2) }}%
+            {{ lines_per | round(precision=precision) }}%
         </td>
         <td class="has-text-centered has-background-{{ lines_sev }} p-2">
             {{ stats.covered_lines }} / {{ stats.total_lines }}
         </td>
         <!-- -->
-        <td class="has-text-centered has-background-{{ functions_sev }} p-2">{{ functions_per | round(precision=2) }}%</td>
+        <td class="has-text-centered has-background-{{ functions_sev }} p-2">{{ functions_per | round(precision=precision) }}%</td>
         <td class="has-text-centered has-background-{{ functions_sev }} p-2">{{ stats.covered_funs }} / {{ stats.total_funs }} </td>
         <!-- -->
-        <td class="has-text-centered has-background-{{ branches_sev }} p-2">{{ branches_per | round(precision=2) }}%</td>
+        <td class="has-text-centered has-background-{{ branches_sev }} p-2">{{ branches_per | round(precision=precision) }}%</td>
         <td class="has-text-centered has-background-{{ branches_sev }} p-2">{{ stats.covered_branches }} / {{ stats.total_branches }}</td>
     </tr>
 {% endmacro %}


### PR DESCRIPTION
Currently multiple report types have different precision values. For example:
1. `markdown.md` has integer precision i.e. `12%`
2. `html/index.html` has 2 decimal precision i.e. `12.34%` but `html/coverage.json` only has integer precision i.e. `12%`
3. `covdir` has actual 2 decimal precision i.e. `12.23%` with some subtleties of the `serder_json`

The current PR:
1. create a command line arg `--precision` for the user to control the precision of all the reports types
2. propagates this precision to `markdown.md`
3. propagates this precision to `html/*` 
4. propagates this precision to `covdir`
5. no action on other output formats since they seem to have their own coverage precision formats.

  