### PR TITLE
Remove clippy false positive bypass

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -472,9 +472,6 @@ fn main() {
     let output_path = match output_types.len() {
         0 => return,
         1 => opt.output_path.as_deref(),
-        //TODO: Remove this #[allow()] which is a false positive clippy warning
-        //      see issue https://github.com/mozilla/grcov/issues/980
-        #[allow(clippy::manual_filter)]
         _ => match opt.output_path.as_deref() {
             Some(output_path) => {
                 if output_path.is_dir() {


### PR DESCRIPTION
Since the this previous PR https://github.com/mozilla/grcov/pull/979, a new version of rust was released. And Github Action is now setting up the [new rust 1.68.0](https://github.com/mozilla/grcov/actions/runs/4438049820/jobs/7788575484?pr=983#step:4:11)  vs the [old rust 1.67.1](https://github.com/mozilla/grcov/actions/runs/4374042184/jobs/7652967163#step:4:12), thus the clippy bypass is no longer needed.

Closes #980