### PR TITLE
Update clap to v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,7 @@ dependencies = [
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
+ "terminal_size",
 ]
 
 [[package]]
@@ -1443,6 +1444,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c9afddd2cec1c0909f06b00ef33f94ab2cc0578c4a610aa208ddfec8aa2b43a"
+dependencies = [
+ "rustix",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487f1e0fcbe47deb8b0574e646def1c903389d95241dd1bbcc6ce4a715dfc0c1"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,35 +248,33 @@ checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "strsim 0.8.0",
- "textwrap 0.11.0",
+ "textwrap",
  "unicode-width",
  "vec_map",
 ]
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "4.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "42dfd32784433290c51d92c438bb72ea5063797fc3cc9a21a8c4346bebbb2098"
 dependencies = [
- "atty",
- "bitflags",
+ "bitflags 2.0.2",
  "clap_derive",
  "clap_lex",
- "indexmap",
+ "is-terminal",
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
- "textwrap 0.16.0",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "4.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "fddf67631444a3a3e3e5ac51c36a5e01335302de677bd78759eaa90ab1f46644"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -281,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "033f6b7a4acb1f358c742aaca805c939ee73b4c6209ae4318ec7aca81c42e646"
 dependencies = [
  "os_str_bytes",
 ]
@@ -538,7 +542,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "ignore",
  "walkdir",
 ]
@@ -549,7 +553,7 @@ version = "0.8.15"
 dependencies = [
  "cargo-binutils",
  "chrono",
- "clap 3.2.23",
+ "clap 4.1.11",
  "crossbeam-channel",
  "flate2",
  "globset",
@@ -579,12 +583,6 @@ dependencies = [
  "walkdir",
  "zip",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
@@ -658,16 +656,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "1.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
-dependencies = [
- "autocfg",
- "hashbrown",
-]
-
-[[package]]
 name = "infer"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,6 +681,18 @@ checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8687c819457e979cc940d09cb16e42a1bf70aa6b60a549de6d3a62a0ee90c69e"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
  "windows-sys 0.45.0",
 ]
 
@@ -812,7 +812,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfb67c6dd0fa9b00619c41c5700b6f92d5f418be49b45ddb9970fbd4569df3c8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1125,7 +1125,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1181,7 +1181,7 @@ version = "0.36.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -1453,12 +1453,6 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ demangle-with-swift = [
 [dependencies]
 cargo-binutils = "0.3"
 chrono = { version = "0.4", features = ["serde"] }
-clap = { version = "4.1", features = ["derive", "deprecated"] }
+clap = { version = "4.1", features = ["cargo", "derive", "deprecated", "wrap_help"] }
 crossbeam-channel = "0.5"
 flate2 = "1.0"
 globset = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ demangle-with-swift = [
 [dependencies]
 cargo-binutils = "0.3"
 chrono = { version = "0.4", features = ["serde"] }
-clap = { version = "3.2", features = ["derive", "deprecated"] }
+clap = { version = "4.1", features = ["derive", "deprecated"] }
 crossbeam-channel = "0.5"
 flate2 = "1.0"
 globset = "0.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@
 #[global_allocator]
 static GLOBAL: tcmalloc::TCMalloc = tcmalloc::TCMalloc;
 
-use clap::{ArgGroup, Parser};
+use clap::{builder::PossibleValue, ArgGroup, Parser, ValueEnum};
 use crossbeam_channel::bounded;
 use log::error;
 use regex::Regex;
@@ -19,6 +19,7 @@ use std::{process, thread};
 
 use grcov::*;
 
+#[derive(Clone)]
 enum OutputType {
     Ade,
     Lcov,
@@ -93,7 +94,7 @@ impl FromStr for Filter {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 struct LevelFilterArg(LevelFilter);
 
-impl clap::ValueEnum for LevelFilterArg {
+impl ValueEnum for LevelFilterArg {
     fn value_variants<'a>() -> &'a [Self] {
         &[
             Self(LevelFilter::Off),
@@ -105,20 +106,20 @@ impl clap::ValueEnum for LevelFilterArg {
         ]
     }
 
-    fn to_possible_value<'a>(&self) -> Option<clap::PossibleValue<'a>> {
+    fn to_possible_value(&self) -> Option<PossibleValue> {
         match self.0 {
-            LevelFilter::Off => Some(clap::PossibleValue::new("OFF")),
-            LevelFilter::Error => Some(clap::PossibleValue::new("ERROR")),
-            LevelFilter::Warn => Some(clap::PossibleValue::new("WARN")),
-            LevelFilter::Info => Some(clap::PossibleValue::new("INFO")),
-            LevelFilter::Debug => Some(clap::PossibleValue::new("DEBUG")),
-            LevelFilter::Trace => Some(clap::PossibleValue::new("TRACE")),
+            LevelFilter::Off => Some(PossibleValue::new("OFF")),
+            LevelFilter::Error => Some(PossibleValue::new("ERROR")),
+            LevelFilter::Warn => Some(PossibleValue::new("WARN")),
+            LevelFilter::Info => Some(PossibleValue::new("INFO")),
+            LevelFilter::Debug => Some(PossibleValue::new("DEBUG")),
+            LevelFilter::Trace => Some(PossibleValue::new("TRACE")),
         }
     }
 }
 
 #[derive(Parser)]
-#[clap(
+#[command(
     author,
     about = "Parse, collect and aggregate code coverage data for multiple source files",
     // This group requires that at least one of --token and --service-job-id
@@ -128,21 +129,21 @@ impl clap::ValueEnum for LevelFilterArg {
     // - --token --service-job-id --service-name
     // - --service-job-id --service-name
     group = ArgGroup::new("coveralls-auth")
-        .args(&["token", "service-job-id"])
+        .args(&["token", "service_job_id"])
         .multiple(true),
 )]
 struct Opt {
     /// Sets the input paths to use.
-    #[clap(required = true)]
+    #[arg(required = true)]
     paths: Vec<String>,
     /// Sets the path to the compiled binary to be used.
-    #[clap(short, long, value_name = "PATH")]
+    #[arg(short, long, value_name = "PATH")]
     binary_path: Option<PathBuf>,
     /// Sets the path to the LLVM bin directory.
-    #[clap(long, value_name = "PATH")]
+    #[arg(long, value_name = "PATH")]
     llvm_path: Option<PathBuf>,
     /// Sets a custom output type.
-    #[clap(
+    #[arg(
         long,
         long_help = "\
             Comma separated list of custom output types:\n\
@@ -157,17 +158,17 @@ struct Opt {
             - *cobertura* for output in cobertura format.\n\
         ",
         value_name = "OUTPUT TYPE",
-        requires_ifs = &[
+        requires_ifs = [
             ("coveralls", "coveralls-auth"),
             ("coveralls+", "coveralls-auth"),
         ],
 
-        use_value_delimiter = true,
-        conflicts_with = "output-type"
+        value_delimiter = ',',
+        conflicts_with = "output_type"
     )]
     output_types: Vec<OutputType>,
     /// Sets a custom output type.
-    #[clap(
+    #[arg(
             short = 't',
             long,
             long_help = "\
@@ -183,116 +184,116 @@ struct Opt {
             - *cobertura* for output in cobertura format.\n\
             ",
             value_name = "OUTPUT TYPE",
-            requires_ifs = &[
+            requires_ifs = [
             ("coveralls", "coveralls-auth"),
             ("coveralls+", "coveralls-auth"),
             ],
 
-            use_value_delimiter = true,
-            conflicts_with = "output-types"
+            value_delimiter = ',',
+            conflicts_with = "output_types"
     )]
     output_type: Option<OutputType>,
     /// Specifies the output path. This is a file for a single output type and must be a folder
     /// for multiple output types.
-    #[clap(short, long, value_name = "PATH", alias = "output-file")]
+    #[arg(short, long, value_name = "PATH", alias = "output-file")]
     output_path: Option<PathBuf>,
     /// Specifies the output config file.
-    #[clap(long, value_name = "PATH", alias = "output-config-file")]
+    #[arg(long, value_name = "PATH", alias = "output-config-file")]
     output_config_file: Option<PathBuf>,
     /// Specifies the root directory of the source files.
-    #[clap(short, long, value_name = "DIRECTORY")]
+    #[arg(short, long, value_name = "DIRECTORY")]
     source_dir: Option<PathBuf>,
     /// Specifies a prefix to remove from the paths (e.g. if grcov is run on a different machine
     /// than the one that generated the code coverage information).
-    #[clap(short, long, value_name = "PATH")]
+    #[arg(short, long, value_name = "PATH")]
     prefix_dir: Option<PathBuf>,
     /// Ignore source files that can't be found on the disk.
-    #[clap(long)]
+    #[arg(long)]
     ignore_not_existing: bool,
     /// Ignore files/directories specified as globs.
-    #[clap(long = "ignore", value_name = "PATH", number_of_values = 1)]
+    #[arg(long = "ignore", value_name = "PATH", num_args = 1)]
     ignore_dir: Vec<String>,
     /// Keep only files/directories specified as globs.
-    #[clap(long = "keep-only", value_name = "PATH", number_of_values = 1)]
+    #[arg(long = "keep-only", value_name = "PATH", num_args = 1)]
     keep_dir: Vec<String>,
-    #[clap(long, value_name = "PATH")]
+    #[arg(long, value_name = "PATH")]
     path_mapping: Option<PathBuf>,
     /// Enables parsing branch coverage information.
-    #[clap(long)]
+    #[arg(long)]
     branch: bool,
     /// Filters out covered/uncovered files. Use 'covered' to only return covered files, 'uncovered'
     /// to only return uncovered files.
-    #[clap(long, value_enum)]
+    #[arg(long, value_enum)]
     filter: Option<Filter>,
     /// Speeds-up parsing, when the code coverage information is exclusively coming from a llvm
     /// build.
-    #[clap(long)]
+    #[arg(long)]
     llvm: bool,
     /// Sets the repository token from Coveralls, required for the 'coveralls' and 'coveralls+'
     /// formats.
-    #[clap(long, value_name = "TOKEN")]
+    #[arg(long, value_name = "TOKEN")]
     token: Option<String>,
     /// Sets the hash of the commit used to generate the code coverage data.
-    #[clap(long, value_name = "COMMIT HASH")]
+    #[arg(long, value_name = "COMMIT HASH")]
     commit_sha: Option<String>,
     /// Sets the service name.
-    #[clap(long, value_name = "SERVICE NAME")]
+    #[arg(long, value_name = "SERVICE NAME")]
     service_name: Option<String>,
     /// Sets the service number.
-    #[clap(long, value_name = "SERVICE NUMBER")]
+    #[arg(long, value_name = "SERVICE NUMBER")]
     service_number: Option<String>,
     /// Sets the service job id.
-    #[clap(
+    #[arg(
         long,
         value_name = "SERVICE JOB ID",
         visible_alias = "service-job-number",
-        requires = "service-name"
+        requires = "service_name"
     )]
     service_job_id: Option<String>,
     /// Sets the service pull request number.
-    #[clap(long, value_name = "SERVICE PULL REQUEST")]
+    #[arg(long, value_name = "SERVICE PULL REQUEST")]
     service_pull_request: Option<String>,
     /// Sets the build type to be parallel for 'coveralls' and 'coveralls+' formats.
-    #[clap(long)]
+    #[arg(long)]
     parallel: bool,
-    #[clap(long, value_name = "NUMBER")]
+    #[arg(long, value_name = "NUMBER")]
     threads: Option<usize>,
     /// Sets coverage decimal point precision on output reports.
-    #[clap(long, value_name = "NUMBER", default_value = "2")]
+    #[arg(long, value_name = "NUMBER", default_value = "2")]
     precision: usize,
-    #[clap(long = "guess-directory-when-missing")]
+    #[arg(long = "guess-directory-when-missing")]
     guess_directory: bool,
     /// Set the branch for coveralls report. Defaults to 'master'.
-    #[clap(long, value_name = "VCS BRANCH", default_value = "master")]
+    #[arg(long, value_name = "VCS BRANCH", default_value = "master")]
     vcs_branch: String,
     /// Set the file where to log (or stderr or stdout). Defaults to 'stderr'.
-    #[clap(long, value_name = "LOG", default_value = "stderr")]
+    #[arg(long, value_name = "LOG", default_value = "stderr")]
     log: PathBuf,
     /// Set the log level.
-    #[clap(long, value_name = "LEVEL", default_value = "ERROR", value_enum)]
+    #[arg(long, value_name = "LEVEL", default_value = "ERROR", value_enum)]
     log_level: LevelFilterArg,
     /// Lines in covered files containing this marker will be excluded.
-    #[clap(long, value_name = "regex")]
+    #[arg(long, value_name = "regex")]
     excl_line: Option<Regex>,
     /// Marks the beginning of an excluded section. The current line is part of this section.
-    #[clap(long, value_name = "regex")]
+    #[arg(long, value_name = "regex")]
     excl_start: Option<Regex>,
     /// Marks the end of an excluded section. The current line is part of this section.
-    #[clap(long, value_name = "regex")]
+    #[arg(long, value_name = "regex")]
     excl_stop: Option<Regex>,
     /// Lines in covered files containing this marker will be excluded from branch coverage.
-    #[clap(long, value_name = "regex")]
+    #[arg(long, value_name = "regex")]
     excl_br_line: Option<Regex>,
     /// Marks the beginning of a section excluded from branch coverage. The current line is part of
     /// this section.
-    #[clap(long, value_name = "regex")]
+    #[arg(long, value_name = "regex")]
     excl_br_start: Option<Regex>,
     /// Marks the end of a section excluded from branch coverage. The current line is part of this
     /// section.
-    #[clap(long, value_name = "regex")]
+    #[arg(long, value_name = "regex")]
     excl_br_stop: Option<Regex>,
     /// No symbol demangling.
-    #[clap(long)]
+    #[arg(long)]
     no_demangle: bool,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,7 +121,16 @@ impl ValueEnum for LevelFilterArg {
 #[derive(Parser)]
 #[command(
     author,
+    version,
+    max_term_width = 100,
     about = "Parse, collect and aggregate code coverage data for multiple source files",
+    help_template = "\
+{before-help}{name}
+{author-with-newline}{about-with-newline}
+{usage-heading} {usage}
+
+{all-args}{after-help}
+",
     // This group requires that at least one of --token and --service-job-id
     // be present. --service-job-id requires --service-name, so this
     // effectively means we accept the following combinations:


### PR DESCRIPTION
This is a followup to #997 

From an user's perspective this should largely mimic clap v3. The main differences now are that the help-text primarily uses non-colored styling now (I believe making this configurable is one of the goals of clap v5), and the flags and args are now sorted in definition order instead of alphabetically. Here's the start of the old and new short-help for comparison

![image](https://user-images.githubusercontent.com/30302768/227754402-e3e274c6-136a-4437-a4ec-a90c109d3dca.png)

![image](https://user-images.githubusercontent.com/30302768/227754431-bf8a0be3-3949-4af8-9387-027441f94c20.png)
