### PR TITLE
Consolidate `--output-type` and `--output-types`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -153,6 +153,7 @@ struct Opt {
     llvm_path: Option<PathBuf>,
     /// Sets a custom output type.
     #[arg(
+        short = 't',
         long,
         long_help = "\
             Comma separated list of custom output types:\n\
@@ -173,35 +174,10 @@ struct Opt {
         ],
 
         value_delimiter = ',',
-        conflicts_with = "output_type"
+        alias = "output-type",
+        default_value = "lcov",
     )]
     output_types: Vec<OutputType>,
-    /// Sets a custom output type.
-    #[arg(
-            short = 't',
-            long,
-            long_help = "\
-            Sets a custom output type::\n\
-            - *html* for a HTML coverage report;\n\
-            - *coveralls* for the Coveralls specific format;\n\
-            - *lcov* for the lcov INFO format;\n\
-            - *covdir* for the covdir recursive JSON format;\n\
-            - *coveralls+* for the Coveralls specific format with function information;\n\
-            - *ade* for the ActiveData-ETL specific format;\n\
-            - *files* to only return a list of files.\n\
-            - *markdown* for human easy read.\n\
-            - *cobertura* for output in cobertura format.\n\
-            ",
-            value_name = "OUTPUT TYPE",
-            requires_ifs = [
-            ("coveralls", "coveralls-auth"),
-            ("coveralls+", "coveralls-auth"),
-            ],
-
-            value_delimiter = ',',
-            conflicts_with = "output_types"
-    )]
-    output_type: Option<OutputType>,
     /// Specifies the output path. This is a file for a single output type and must be a folder
     /// for multiple output types.
     #[arg(short, long, value_name = "PATH", alias = "output-file")]
@@ -495,13 +471,10 @@ fn main() {
     let service_pull_request = opt.service_pull_request.unwrap_or_default();
     let commit_sha = opt.commit_sha.unwrap_or_default();
 
-    let output_types = match opt.output_type {
-        Some(output_type) => vec![output_type],
-        None => opt.output_types,
-    };
+    let output_types = opt.output_types;
 
     let output_path = match output_types.len() {
-        0 => return,
+        0 => unreachable!("Output types has a default value"),
         1 => opt.output_path.as_deref(),
         _ => match opt.output_path.as_deref() {
             Some(output_path) => {


### PR DESCRIPTION
Fixes #1002

As discussed in #1002 this combines `--output-type` and `--output-types` using an alias and changes the default output type to lcov