### PR TITLE
Follow symlinks in binary_path

### DIFF
--- a/src/llvm_tools.rs
+++ b/src/llvm_tools.rs
@@ -106,8 +106,8 @@ pub fn profraws_to_lcov(
         let mut paths = vec![];
 
         for entry in WalkDir::new(binary_path).follow_links(true) {
-            let entry =
-                entry.unwrap_or_else(|e| panic!("Failed to open directory '{:?}': {}", binary_path, e));
+            let entry = entry
+                .unwrap_or_else(|e| panic!("Failed to open directory '{:?}': {}", binary_path, e));
 
             if is_binary(entry.path()) && entry.metadata().unwrap().len() > 0 {
                 paths.push(entry.into_path());

--- a/src/llvm_tools.rs
+++ b/src/llvm_tools.rs
@@ -105,9 +105,9 @@ pub fn profraws_to_lcov(
     } else {
         let mut paths = vec![];
 
-        for entry in WalkDir::new(binary_path) {
+        for entry in WalkDir::new(binary_path).follow_links(true) {
             let entry =
-                entry.unwrap_or_else(|_| panic!("Failed to open directory '{:?}'.", binary_path));
+                entry.unwrap_or_else(|e| panic!("Failed to open directory '{:?}': {}", binary_path, e));
 
             if is_binary(entry.path()) && entry.metadata().unwrap().len() > 0 {
                 paths.push(entry.into_path());


### PR DESCRIPTION
I'm using grcov to generate coverage info for a medium-sized CMake C++ project - I found that if I pointed the binary path to the root of my build artifacts tree, grcov could run for 45 minutes without producing any results. I see others have run into similar issues and there are open issues to improve the performance of scanning the binary path or to allow you to list multiple binary paths. The solution I came up with in the short term was to make it so grcov could follow symlinks in the binary path, and then in my CI environment where I generate coverage info, I drop a symlink to each binary that's generating coverage info into a `coverage_binaries` directory and pass that in as the binary path to grcov. That way it only has to scan the specific binaries there's definitely coverage info for, and not the entire build tree. I also updated the message passed to `panic!` when scanning a directory fails so you get actual diagnostics about what went wrong.