### PR TITLE
Corrected instructions for using '-t lcov' and 'genhtml' with lcov file

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,14 +265,18 @@ N.B.: The `--binary-path` argument is only necessary for source-based coverage.
 
 You can see the report in `target/debug/coverage/index.html`.
 
-(or alternatively with `-t lcov` grcov will output a lcov compatible coverage report that you could then feed into lcov's `genhtml` command).
+Or alternatively with `-t lcov`, grcov will output a lcov compatible coverage report
+
+```sh
+grcov . -s . --binary-path ./target/debug/ -t lcov --branch --ignore-not-existing -o ./target/debug/
+```
 
 #### LCOV output
 
-By passing `-t lcov` you could generate an lcov.info file and pass it to genhtml:
+The above command will generate a file called `lcov` in `./target/debug`, which you can pass to `genhtml` to generate an HTML report:
 
 ```sh
-genhtml -o ./target/debug/coverage/ --show-details --highlight --ignore-errors source --legend ./target/debug/lcov.info
+genhtml -o ./target/debug/coverage/ --show-details --highlight --ignore-errors source --legend ./target/debug/lcov
 ```
 
 LCOV output should be used when uploading to Codecov, with the `--branch` argument for branch coverage support.


### PR DESCRIPTION
I tried generating an HTML coverage report using the LCOV file, but couldn't get it to work using the current instruction which states:

> (or alternatively with -t lcov grcov will output a lcov compatible coverage report that you could then feed into lcov's genhtml command).

This doesn't work because replacing

```
grcov . -s . --binary-path ./target/debug/ -t html --branch --ignore-not-existing -o ./target/debug/coverage/
```

with 

```
grcov . -s . --binary-path ./target/debug/ -t lcov --branch --ignore-not-existing -o ./target/debug/coverage/
```

generates an error:

```
[ERROR] A panic occurred at /home/saurabh/.local/share/rust/cargo/registry/src/github.com-1ecc6299db9ec823/grcov-0.8.18/src/output.rs:59: Cannot create the file ./target/debug/coverage/ to dump coverage data.
```

Running `cargo test` creates directory `./target/debug/` containing files and other directories. But none of these directories are called `coverage`. I also noticed that **`-t html` creates the `coverage` directory in `./target/debug/`, but `-t lcov` doesn't.**

`-t lcov` flag can be used correctly by:

```
grcov . -s . --binary-path ./target/debug/ -t lcov --branch --ignore-not-existing -o ./target/debug/
```

This generates a file called `lcov` (not `lcov.info`) in `./target/debug/`

Following this, an HTML report can be generated with:

```
genhtml -o ./target/debug/coverage/ --show-details --highlight --ignore-errors source --legend ./target/debug/lcov
```
