### PR TITLE
Update error message to indicate if a directory doesn't exist to dump coverage file

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -50,14 +50,14 @@ pub fn get_target_output_writable(output_file: Option<&Path>) -> Box<dyn Write> 
                 if let Some(parent_path) = parent {
                     if !parent_path.exists() {
                         panic!(
-                            "Cannot create {} to dump coverage data, as {} doesn't exist",
+                            "Cannot create file {} to dump coverage data, as directory {} doesn't exist",
                             output.display(),
                             parent_path.display()
                         )
                     }
                 }
                 panic!(
-                    "Cannot create the file {} to dump coverage data.",
+                    "Cannot create file {} to dump coverage data, as the directory doesn't exist",
                     output.display()
                 )
             }))

--- a/src/output.rs
+++ b/src/output.rs
@@ -57,7 +57,7 @@ pub fn get_target_output_writable(output_file: Option<&Path>) -> Box<dyn Write> 
                     }
                 }
                 panic!(
-                    "Cannot create file {} to dump coverage data.",
+                    "Cannot create the file {} to dump coverage data.",
                     output.display()
                 )
             }))

--- a/src/output.rs
+++ b/src/output.rs
@@ -50,14 +50,14 @@ pub fn get_target_output_writable(output_file: Option<&Path>) -> Box<dyn Write> 
                 if let Some(parent_path) = parent {
                     if !parent_path.exists() {
                         panic!(
-                            "Cannot create file {} to dump coverage data, as directory {} doesn't exist",
+                            "Cannot create file {} to dump coverage data, as the parent directory {} doesn't exist.",
                             output.display(),
                             parent_path.display()
                         )
                     }
                 }
                 panic!(
-                    "Cannot create file {} to dump coverage data, as the directory doesn't exist",
+                    "Cannot create file {} to dump coverage data.",
                     output.display()
                 )
             }))


### PR DESCRIPTION
Modified function `get_target_output_writable` in `src/output.rs`.
Updated error message indicates if a directory doesn't exist for dumping the coverage file.