### PR TITLE
Add argument to sort output types

### DIFF
--- a/src/path_rewriting.rs
+++ b/src/path_rewriting.rs
@@ -341,9 +341,7 @@ pub fn rewrite_paths(
             Some((abs_path, rel_path, result))
         });
 
-    let mut results_vec: Vec<_> = results.collect();
-    results_vec.sort_by_key(|result| result.0.display().to_string());
-    results_vec
+    results.collect()
 }
 
 #[cfg(test)]

--- a/src/path_rewriting.rs
+++ b/src/path_rewriting.rs
@@ -341,7 +341,9 @@ pub fn rewrite_paths(
             Some((abs_path, rel_path, result))
         });
 
-    results.collect()
+    let mut results_vec: Vec<_> = results.collect();
+    results_vec.sort_by_key(|result| result.0.display().to_string());
+    results_vec
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Adds optional argument to specify a list of output types to sort files for. Sorts final results lexicographically by filepath for relevant types. Defaults to only markdown, as this format is intended to be human readable

Resolves #1057