### PR TITLE
Replace `zip` with `zip_next`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,9 +190,9 @@ checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "camino"
@@ -381,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
 ]
@@ -424,12 +433,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crypto-common"
@@ -448,6 +454,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -630,7 +647,7 @@ dependencies = [
  "tera",
  "uuid",
  "walkdir",
- "zip",
+ "zip_next",
 ]
 
 [[package]]
@@ -1812,11 +1829,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
-name = "zip"
-version = "0.6.6"
+name = "zip_next"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+checksum = "658758d431446f97e25f129b30c97646db8799b30f00aaf10379b4fa343d4ded"
 dependencies = [
+ "arbitrary",
  "byteorder",
  "crc32fast",
  "crossbeam-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,9 @@ edition = "2018"
 [features]
 default = ["deflate-zlib", "demangle-no-swift"]
 tc = ["tcmalloc"]
-deflate = ["zip/deflate"]
-deflate-miniz = ["zip/deflate-miniz"]
-deflate-zlib = ["zip/deflate-zlib"]
+deflate = ["zip_next/deflate"]
+deflate-miniz = ["zip_next/deflate-miniz"]
+deflate-zlib = ["zip_next/deflate-zlib"]
 demangle-no-swift = ["symbolic-demangle/cpp", "symbolic-demangle/msvc", "symbolic-demangle/rust"]
 demangle-with-swift = [
     "symbolic-demangle/cpp",
@@ -66,7 +66,7 @@ tempfile = "3.8"
 tera = "1.19"
 uuid = { version = "1.5", features = ["v4"] }
 walkdir = "2.4"
-zip = { version = "0.6", default-features = false }
+zip_next = { version = "1.0", default-features = false }
 
 [dev-dependencies]
 pretty_assertions = "1.2"

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -5,7 +5,7 @@ use std::fs::{self, File};
 use std::io::{self, BufReader, Read};
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
-use zip::ZipArchive;
+use zip_next::ZipArchive;
 
 use crate::defs::*;
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -7,8 +7,8 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::{env, fs};
 use walkdir::WalkDir;
-use zip::write::FileOptions;
-use zip::ZipWriter;
+use zip_next::write::FileOptions;
+use zip_next::ZipWriter;
 
 fn get_tool(name: &str, default: &str) -> String {
     match env::var(name) {


### PR DESCRIPTION
The `zip` crate hasn't been updated in almost a year, and has a number of bugs that can cause panics when trying to process an invalid zip file. This PR replaces it with `zip_next`, a fork I actively maintain.