### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,15 +374,15 @@ build:
         --output-types html,cobertura
 
     # Extract just the top-level coverage number from the XML report.
-    - xmllint --xpath "concat('Coverage: ', 100 * string(//coverage/@line-rate), '%')" target/coverage/cobertura.xml
-  coverage: '/Coverage: \d+(?:\.\d+)?/'
+    - xmllint --xpath "concat('Coverage - ', 100 * string(//coverage/@line-rate), '%')" target/coverage/cobertura.xml
+  coverage: '/Coverage - \d+(?:\.\d+)?/'
   artifacts:
     paths:
       - target/coverage/
     reports:
       coverage_report:
         coverage_format: cobertura
-        path: target/coverage.xml
+        path: target/coverage/cobertura.xml
 ```
 
 This also ties into Gitlab's coverage percentage collection, so in merge requests you'll be able to see:


### PR DESCRIPTION
Two modifications in `.gitlab-ci-yml`
1. Fix the .xml path so that the report can be found by GitLab
2. Replace ':' by '-' since YAML keeps ':' as an keyword