### PR TITLE
Add the `--no-date` flag to disable including the current date

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -32,13 +32,13 @@ pub struct Config {
     fn_med_limit: f64,
     branch_hi_limit: f64,
     branch_med_limit: f64,
-    date: DateTime<Utc>,
+    date: Option<DateTime<Utc>>,
     branch_enabled: bool,
     precision: usize,
 }
 
 impl Config {
-    fn new(cfg: &ConfigFile, branch_enabled: bool, precision: usize) -> Config {
+    fn new(cfg: &ConfigFile, branch_enabled: bool, precision: usize, no_date: bool) -> Config {
         Config {
             hi_limit: cfg.hi_limit.unwrap_or(90.),
             med_limit: cfg.med_limit.unwrap_or(75.),
@@ -46,7 +46,7 @@ impl Config {
             fn_med_limit: cfg.fn_med_limit.unwrap_or(75.),
             branch_hi_limit: cfg.branch_hi_limit.unwrap_or(90.),
             branch_med_limit: cfg.branch_med_limit.unwrap_or(75.),
-            date: Utc::now(),
+            date: if no_date { None } else { Some(Utc::now()) },
             branch_enabled,
             precision,
         }
@@ -126,9 +126,10 @@ pub fn get_config(
     output_config_file: Option<&Path>,
     branch_enabled: bool,
     precision: usize,
+    no_date: bool,
 ) -> (Tera, Config) {
     let user_conf = ConfigFile::load(output_config_file);
-    let conf = Config::new(&user_conf, branch_enabled, precision);
+    let conf = Config::new(&user_conf, branch_enabled, precision, no_date);
 
     let mut tera = Tera::default();
 

--- a/src/html.rs
+++ b/src/html.rs
@@ -33,10 +33,12 @@ pub struct Config {
     branch_hi_limit: f64,
     branch_med_limit: f64,
     date: DateTime<Utc>,
+    branch_enabled: bool,
+    precision: usize,
 }
 
 impl Config {
-    fn new(cfg: &ConfigFile) -> Config {
+    fn new(cfg: &ConfigFile, branch_enabled: bool, precision: usize) -> Config {
         Config {
             hi_limit: cfg.hi_limit.unwrap_or(90.),
             med_limit: cfg.med_limit.unwrap_or(75.),
@@ -45,6 +47,8 @@ impl Config {
             branch_hi_limit: cfg.branch_hi_limit.unwrap_or(90.),
             branch_med_limit: cfg.branch_med_limit.unwrap_or(75.),
             date: Utc::now(),
+            branch_enabled,
+            precision,
         }
     }
 }
@@ -118,9 +122,13 @@ fn get_templates(user_templates: &Option<HashMap<String, String>>) -> HashMap<St
     result
 }
 
-pub fn get_config(output_config_file: Option<&Path>) -> (Tera, Config) {
+pub fn get_config(
+    output_config_file: Option<&Path>,
+    branch_enabled: bool,
+    precision: usize,
+) -> (Tera, Config) {
     let user_conf = ConfigFile::load(output_config_file);
-    let conf = Config::new(&user_conf);
+    let conf = Config::new(&user_conf, branch_enabled, precision);
 
     let mut tera = Tera::default();
 
@@ -260,22 +268,20 @@ fn get_dirs_result(global: Arc<Mutex<HtmlGlobalStats>>, rel_path: &Path, stats: 
 
 use tera::{Context, Tera};
 
-fn make_context() -> Context {
+fn make_context(conf: &Config) -> Context {
     let mut ctx = Context::new();
+
     let ver = std::env::var("BULMA_VERSION").map_or(BULMA_VERSION.into(), |v| v);
     ctx.insert("bulma_version", &ver);
+
+    ctx.insert("date", &conf.date);
+    ctx.insert("precision", &conf.precision);
+    ctx.insert("branch_enabled", &conf.branch_enabled);
 
     ctx
 }
 
-pub fn gen_index(
-    tera: &Tera,
-    global: &HtmlGlobalStats,
-    conf: &Config,
-    output: &Path,
-    branch_enabled: bool,
-    precision: usize,
-) {
+pub fn gen_index(tera: &Tera, global: &HtmlGlobalStats, conf: &Config, output: &Path) {
     let output_file = output.join("index.html");
     create_parent(&output_file);
     let mut output_stream = match File::create(&output_file) {
@@ -286,16 +292,13 @@ pub fn gen_index(
         Ok(f) => f,
     };
 
-    let mut ctx = make_context();
+    let mut ctx = make_context(conf);
     let empty: &[&str] = &[];
-    ctx.insert("date", &conf.date);
     ctx.insert("current", "top_level");
     ctx.insert("parents", empty);
     ctx.insert("stats", &global.stats);
-    ctx.insert("precision", &precision);
     ctx.insert("items", &global.dirs);
     ctx.insert("kind", "Directory");
-    ctx.insert("branch_enabled", &branch_enabled);
 
     let out = tera.render("index.html", &ctx).unwrap();
 
@@ -305,15 +308,7 @@ pub fn gen_index(
     }
 
     for (dir_name, dir_stats) in global.dirs.iter() {
-        gen_dir_index(
-            tera,
-            dir_name,
-            dir_stats,
-            conf,
-            output,
-            branch_enabled,
-            precision,
-        );
+        gen_dir_index(tera, dir_name, dir_stats, conf, output);
     }
 }
 
@@ -323,8 +318,6 @@ pub fn gen_dir_index(
     dir_stats: &HtmlDirStats,
     conf: &Config,
     output: &Path,
-    branch_enabled: bool,
-    precision: usize,
 ) {
     let index = Path::new(dir_name).join("index.html");
     let layers = index.components().count() - 1;
@@ -339,16 +332,12 @@ pub fn gen_dir_index(
         Ok(f) => f,
     };
 
-    let mut ctx = make_context();
-    ctx.insert("date", &conf.date);
-    ctx.insert("bulma_version", BULMA_VERSION);
+    let mut ctx = make_context(conf);
     ctx.insert("current", dir_name);
     ctx.insert("parents", &[(prefix, "top_level")]);
     ctx.insert("stats", &dir_stats.stats);
     ctx.insert("items", &dir_stats.files);
     ctx.insert("kind", "File");
-    ctx.insert("branch_enabled", &branch_enabled);
-    ctx.insert("precision", &precision);
 
     let out = tera.render("index.html", &ctx).unwrap();
 
@@ -365,8 +354,6 @@ fn gen_html(
     output: &Path,
     rel_path: &Path,
     global: Arc<Mutex<HtmlGlobalStats>>,
-    branch_enabled: bool,
-    precision: usize,
 ) {
     if !rel_path.is_relative() {
         return;
@@ -398,9 +385,7 @@ fn gen_html(
     let mut index_url = base_url;
     index_url.push_str("index.html");
 
-    let mut ctx = make_context();
-    ctx.insert("date", &conf.date);
-    ctx.insert("bulma_version", BULMA_VERSION);
+    let mut ctx = make_context(conf);
     ctx.insert("current", filename);
     ctx.insert(
         "parents",
@@ -410,8 +395,6 @@ fn gen_html(
         ],
     );
     ctx.insert("stats", &stats);
-    ctx.insert("branch_enabled", &branch_enabled);
-    ctx.insert("precision", &precision);
 
     let mut file_buf = Vec::new();
     if let Err(e) = f.read_to_end(&mut file_buf) {
@@ -458,8 +441,6 @@ pub fn consumer_html(
     global: Arc<Mutex<HtmlGlobalStats>>,
     output: &Path,
     conf: Config,
-    branch_enabled: bool,
-    precision: usize,
 ) {
     while let Ok(job) = receiver.recv() {
         if job.is_none() {
@@ -474,8 +455,6 @@ pub fn consumer_html(
             output,
             &job.rel_path,
             global.clone(),
-            branch_enabled,
-            precision,
         );
     }
 }
@@ -540,7 +519,7 @@ pub fn gen_badge(tera: &Tera, stats: &HtmlStats, conf: &Config, output: &Path, s
         Ok(f) => f,
     };
 
-    let mut ctx = make_context();
+    let mut ctx = make_context(conf);
     ctx.insert(
         "current",
         &(get_percentage_of_covered_lines(stats.covered_lines, stats.total_lines) as usize),

--- a/src/main.rs
+++ b/src/main.rs
@@ -297,6 +297,9 @@ struct Opt {
     /// No symbol demangling.
     #[arg(long)]
     no_demangle: bool,
+    /// Do not include the current date in the HTML report.
+    #[arg(long)]
+    no_date: bool,
 }
 
 fn main() {
@@ -562,6 +565,7 @@ fn main() {
                 opt.branch,
                 opt.output_config_file.as_deref(),
                 opt.precision,
+                opt.no_date,
             ),
             OutputType::Cobertura => output_cobertura(
                 source_root.as_deref(),

--- a/src/output.rs
+++ b/src/output.rs
@@ -526,6 +526,7 @@ pub fn output_html(
     branch_enabled: bool,
     output_config_file: Option<&Path>,
     precision: usize,
+    no_date: bool,
 ) {
     let output = if let Some(output_dir) = output_dir {
         PathBuf::from(output_dir)
@@ -547,7 +548,7 @@ pub fn output_html(
 
     let stats = Arc::new(Mutex::new(HtmlGlobalStats::default()));
     let mut threads = Vec::with_capacity(num_threads);
-    let (tera, config) = html::get_config(output_config_file, branch_enabled, precision);
+    let (tera, config) = html::get_config(output_config_file, branch_enabled, precision, no_date);
     for i in 0..num_threads {
         let receiver = receiver.clone();
         let output = output.clone();

--- a/src/output.rs
+++ b/src/output.rs
@@ -547,7 +547,7 @@ pub fn output_html(
 
     let stats = Arc::new(Mutex::new(HtmlGlobalStats::default()));
     let mut threads = Vec::with_capacity(num_threads);
-    let (tera, config) = html::get_config(output_config_file);
+    let (tera, config) = html::get_config(output_config_file, branch_enabled, precision);
     for i in 0..num_threads {
         let receiver = receiver.clone();
         let output = output.clone();
@@ -557,15 +557,7 @@ pub fn output_html(
         let t = thread::Builder::new()
             .name(format!("Consumer HTML {}", i))
             .spawn(move || {
-                html::consumer_html(
-                    &tera,
-                    receiver,
-                    stats,
-                    &output,
-                    config,
-                    branch_enabled,
-                    precision,
-                );
+                html::consumer_html(&tera, receiver, stats, &output, config);
             })
             .unwrap();
 
@@ -594,7 +586,7 @@ pub fn output_html(
 
     let global = Arc::try_unwrap(stats).unwrap().into_inner().unwrap();
 
-    html::gen_index(&tera, &global, &config, &output, branch_enabled, precision);
+    html::gen_index(&tera, &global, &config, &output);
 
     for style in html::BadgeStyle::iter() {
         html::gen_badge(&tera, &global.stats, &config, &output, style);

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -13,9 +13,11 @@
             {%- block content -%}{%- endblock content -%}
         </div>
         <footer class="footer">
-            <div class="content has-text-centered">
-                <p class="heading">Date: {{ date | date(format="%Y-%m-%d %H:%M") }}</p>
-            </div>
+            {% if date %}
+                <div class="content has-text-centered">
+                    <p class="heading">Date: {{ date | date(format="%Y-%m-%d %H:%M") }}</p>
+                </div>
+            {% endif %}
         </footer>
     </body>
 </html>


### PR DESCRIPTION
Right now HTML reports always include the date the report was generated on, which prevents the reports from being reproducible. This adds a `--no-date` flag to avoid including it.

To keep the code maintainable as new options are added, I made a small refactoring in the first commit to set all the global context items in the `get_context()` function, and moving the global options to `Config`.

This PR is best reviewed commit-by-commit.