### PR TITLE
Improve performance of `--source-dir`

### DIFF
--- a/src/path_rewriting.rs
+++ b/src/path_rewriting.rs
@@ -253,12 +253,11 @@ pub fn rewrite_paths(
             let entry = entry
                 .unwrap_or_else(|_| panic!("Failed to open directory '{}'.", source_dir.display()));
 
-            let full_path = entry.path();
-            if !full_path.is_file() {
+            if !entry.file_type().is_file() {
                 continue;
             }
 
-            let path = full_path.strip_prefix(source_dir).unwrap().to_path_buf();
+            let path = entry.path().strip_prefix(source_dir).unwrap().to_path_buf();
             if to_ignore_globset.is_match(&path) {
                 continue;
             }


### PR DESCRIPTION
When trying to run `grcov` in a very large project (containing the Rust repository, all of its submodules, and a large `build/` directory) I noticed that the `--source-dir` flag caused a considerable slowdown:

* `cd path/to/repo && grcov` took 0.06s
* `grcov --source-dir path/to/repo` took 5.4s

It turns out that the code added for https://github.com/mozilla/grcov/pull/196 does a lot of syscalls and allocations when `--source-dir` is passed. In this PR I tried to speed it up a bit, and I got it from 5.4s to 2.8s. Now most of the time is spent in walkdir itself, and improving performance even more would take more time than I have at the moment. Still, I hope the speedup so far is appreciated :D