### PR TITLE
Rollback zip from 2.6 to 2.4.2 (#1351)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ tempfile = "3.19"
 tera = "1.20"
 uuid = { version = "1.16", features = ["v4"] }
 walkdir = "2.5"
-zip = { version = "2.6", default-features = false }
+zip = { version = "2.4.2", default-features = false }
 
 [dev-dependencies]
 pretty_assertions = "1.4"


### PR DESCRIPTION
Rollback [zip](https://github.com/zip-rs/zip2) from 2.6 to 2.4.2.
- [2.6.1 Yank](https://crates.io/crates/zip/2.6.1)
- [2.6.0 Yank](https://crates.io/crates/zip/2.6.0)