### PR TITLE
Allow to ignore lcov parsing error with an argument

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,7 @@ pub fn consumer(
     branch_enabled: bool,
     guess_directory: bool,
     binary_path: Option<&Path>,
+    ignore_parsing_error: bool,
 ) {
     let mut gcov_type = GcovType::Unknown;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,7 +293,7 @@ pub fn consumer(
 
                             for lcov in lcovs {
                                 new_results.append(&mut try_parse!(
-                                    parse_lcov(lcov, branch_enabled),
+                                    parse_lcov(lcov, branch_enabled, ignore_parsing_error),
                                     work_item.name
                                 ));
                             }
@@ -313,7 +313,10 @@ pub fn consumer(
             ItemFormat::Info | ItemFormat::JacocoXml | ItemFormat::Gocov => {
                 if let ItemType::Content(content) = work_item.item {
                     if work_item.format == ItemFormat::Info {
-                        try_parse!(parse_lcov(content, branch_enabled), work_item.name)
+                        try_parse!(
+                            parse_lcov(content, branch_enabled, ignore_parsing_error),
+                            work_item.name
+                        )
                     } else if work_item.format == ItemFormat::JacocoXml {
                         let buffer = BufReader::new(Cursor::new(content));
                         try_parse!(parse_jacoco_xml_report(buffer), work_item.name)
@@ -436,7 +439,7 @@ mod tests {
             .expect("Failed to open lcov file");
         let mut buf = Vec::new();
         f.read_to_end(&mut buf).unwrap();
-        let results = parse_lcov(buf, false).unwrap();
+        let results = parse_lcov(buf, false, false).unwrap();
         let result_map: Arc<SyncCovResultMap> = Arc::new(Mutex::new(
             FxHashMap::with_capacity_and_hasher(1, Default::default()),
         ));
@@ -470,7 +473,7 @@ mod tests {
             .expect("Failed to open lcov file");
         let mut buf = Vec::new();
         f.read_to_end(&mut buf).unwrap();
-        let results = parse_lcov(buf, false).unwrap();
+        let results = parse_lcov(buf, false, false).unwrap();
         let result_map: Arc<SyncCovResultMap> = Arc::new(Mutex::new(
             FxHashMap::with_capacity_and_hasher(3, Default::default()),
         ));

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,6 +201,9 @@ struct Opt {
     /// Ignore source files that can't be found on the disk.
     #[arg(long)]
     ignore_not_existing: bool,
+    /// Ignore error when parsing the coverage files.
+    #[arg(long)]
+    ignore_parsing_error: bool,
     /// Ignore files/directories specified as globs.
     #[arg(long = "ignore", value_name = "PATH", num_args = 1)]
     ignore_dir: Vec<String>,
@@ -447,6 +450,7 @@ fn main() {
         let binary_path = opt.binary_path.clone();
         let branch_enabled = opt.branch;
         let guess_directory = opt.guess_directory;
+        let ignore_parsing_error = opt.ignore_parsing_error;
 
         let t = thread::Builder::new()
             .name(format!("Consumer {i}"))
@@ -460,6 +464,7 @@ fn main() {
                     branch_enabled,
                     guess_directory,
                     binary_path.as_deref(),
+                    ignore_parsing_error,
                 );
             })
             .unwrap();


### PR DESCRIPTION
This Pull Request is related to the issue #1242.

Currently when a coverage file contains malformated chunks, the `parse_lcov` function will raised an Error, causing the whole file to be ignored. In some case, this is fine to have the bad part ignored and the rest of the file correctly parse by grcov.

To achieve that, this patch add the argument `--ignore-parsing-error`. Instead of raising an exception when a parsing error occurs, a warning message will be shown and the malformated chuck will be ignored.