### PR TITLE
Fix HTML directory navigation by unifying file and directory handling

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -8,7 +8,7 @@
     <table class="table is-fullwidth">
         <thead>
             <tr>
-                <th>{{ kind }}</th>
+                <th>Name</th>
                 <th class="has-text-centered" colspan="3">Line Coverage</th>
                 <th class="has-text-centered" colspan="2">Functions</th>
                 {% if branch_enabled %}
@@ -17,23 +17,23 @@
             </tr>
         </thead>
         <tbody>
-            {%- if kind == "Directory" -%}
-                {%- for item, info in items -%}
-                  {% if info.abs_prefix and info.abs_prefix != "" %}
-                    {{ macros::stats_line(name=item, url=info.abs_prefix~item~"/index.html", stats=info.stats, precision=precision) }}
-                  {% else %}
-                    {{ macros::stats_line(name=item, url=item~"/index.html", stats=info.stats, precision=precision) }}
-                  {% endif %}
-                {%- endfor -%}
-            {%- else -%}
-                {%- for item, info in items -%}
-                  {% if info.abs_prefix and info.abs_prefix != "" %}
-                    {{ macros::stats_line(name=item, url=info.abs_prefix~"/"~item~".html", stats=info.stats, precision=precision) }}
-                  {% else %}
-                    {{ macros::stats_line(name=item, url=item~".html", stats=info.stats, precision=precision) }}
-                  {% endif %}
-                {%- endfor -%}
-            {%- endif -%}
+            {%- for item, info in items -%}
+              {%- if info.files is defined -%}
+                {# This is a directory #}
+                {% if info.abs_prefix and info.abs_prefix != "" %}
+                  {{ macros::stats_line(name=item, url=info.abs_prefix~item~"/index.html", stats=info.stats, precision=precision) }}
+                {% else %}
+                  {{ macros::stats_line(name=item, url=item~"/index.html", stats=info.stats, precision=precision) }}
+                {% endif %}
+              {%- else -%}
+                {# This is a file #}
+                {% if info.abs_prefix and info.abs_prefix != "" %}
+                  {{ macros::stats_line(name=item, url=info.abs_prefix~"/"~item~".html", stats=info.stats, precision=precision) }}
+                {% else %}
+                  {{ macros::stats_line(name=item, url=item~".html", stats=info.stats, precision=precision) }}
+                {% endif %}
+              {%- endif -%}
+            {%- endfor -%}
         </tbody>
     </table>
 {%- endblock content -%}


### PR DESCRIPTION
resolve #1343 

HTML coverage reports now properly display both files and subdirectories in the index pages, enabling complete navigation through the project structure.

The original code had separate handling for files and directories with rigid template logic:

- gen_index() only displayed directories (kind = "Directory")
- gen_dir_index() only displayed files (kind = "File")
- No unified method to list both files and directories together.
- The root index.html overwriten by gen_dir_index ended up showing only files, losing all directory navigation