### PR TITLE
Fix build with Rust 1.90

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -210,7 +210,7 @@ pub fn output_covdir(results: &[ResultTuple], output_file: Option<&Path>, precis
                 hash_map::Entry::Occupied(s) => s.get().clone(),
                 hash_map::Entry::Vacant(p) => {
                     let mut prev_stats = prev_stats.borrow_mut();
-                    let path_tail = if ancestor == "/" {
+                    let path_tail = if ancestor.as_os_str() == "/" {
                         "/".to_string()
                     } else {
                         ancestor.file_name().unwrap().to_str().unwrap().to_string()


### PR DESCRIPTION
Path only implements PartialEq<str> starting with Rust 1.91.