### PR TITLE
chore: satisfy clippy on the current toolchain

### DIFF
--- a/src/cobertura.rs
+++ b/src/cobertura.rs
@@ -65,8 +65,8 @@ impl CoverageStats {
         let lines_valid = lines.len() as f64;
 
         let branches: Vec<Vec<Condition>> = lines
-            .into_iter()
-            .filter_map(|(_, l)| match l {
+            .into_values()
+            .filter_map(|l| match l {
                 Line::Branch { conditions, .. } => Some(conditions),
                 Line::Plain { .. } => None,
             })

--- a/src/path_rewriting.rs
+++ b/src/path_rewriting.rs
@@ -417,18 +417,10 @@ pub fn rewrite_paths(
             }
 
             match filter_option {
-                Some(true) => {
-                    if !is_covered(&result) {
-                        return None;
-                    }
-                }
-                Some(false) => {
-                    if is_covered(&result) {
-                        return None;
-                    }
-                }
-                None => (),
-            };
+                Some(true) if !is_covered(&result) => return None,
+                Some(false) if is_covered(&result) => return None,
+                _ => (),
+            }
 
             Some((abs_path, rel_path, result))
         });

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -50,6 +50,11 @@ impl Archive {
             .push(self);
     }
 
+    // The three content checks below read from `file`, which is an
+    // `Option<&mut impl Read>` and so not `Copy`. Moving it in a match guard
+    // makes it moved for the whole match, and the arms stop compiling with
+    // E0382, so the checks have to stay inside the arm bodies.
+    #[allow(clippy::collapsible_match)]
     fn handle_file<'a>(
         &'a self,
         file: Option<&mut impl Read>,
@@ -144,8 +149,7 @@ impl Archive {
 
     fn is_info(reader: &mut dyn Read) -> bool {
         let mut bytes: [u8; 3] = [0; 3];
-        reader.read_exact(&mut bytes).is_ok()
-            && (bytes == [b'T', b'N', b':'] || bytes == [b'S', b'F', b':'])
+        reader.read_exact(&mut bytes).is_ok() && (bytes == *b"TN:" || bytes == *b"SF:")
     }
 
     fn check_file(file: Option<&mut impl Read>, checker: &dyn Fn(&mut dyn Read) -> bool) -> bool {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -581,7 +581,7 @@ fn test_integration_zip_zip() {
 
         // two gcdas
         std::fs::copy(&gcda_zip_path, &gcda1_zip_path)
-            .unwrap_or_else(|_| panic!("Failed to copy {gcda_zip_path:?}"));
+            .unwrap_or_else(|_| panic!("Failed to copy {:?}", gcda_zip_path));
 
         println!("Two gcdas");
         check_equal_coveralls(

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -581,7 +581,7 @@ fn test_integration_zip_zip() {
 
         // two gcdas
         std::fs::copy(&gcda_zip_path, &gcda1_zip_path)
-            .unwrap_or_else(|_| panic!("Failed to copy {:?}", &gcda_zip_path));
+            .unwrap_or_else(|_| panic!("Failed to copy {gcda_zip_path:?}"));
 
         println!("Two gcdas");
         check_equal_coveralls(


### PR DESCRIPTION
`Lint` fails on `master` itself with the clippy CI now installs, so it is red on every pull request opened since that bump - 13 of the 25 open ones when I checked, including 11 dependabot bumps, #1394, and my own #1515 and #1516. None of the findings are in code those branches touch, so nobody can turn their own PR green.

The five findings CI reports, and what this does with each:

| lint | site | change |
| --- | --- | --- |
| `iter_kv_map` | `cobertura.rs:67` | `into_iter().filter_map(\|(_, l)\| ...)` discards the key, so it is `into_values()` |
| `collapsible_match` | `path_rewriting.rs:426` | the two `Some(..)` arms fold into match guards |
| `byte_char_slices` x2 | `producer.rs:148` | `[b'T', b'N', b':']` is `*b"TN:"` |
| `collapsible_match` | `producer.rs:112` | allowed, see below |

The last one is the only judgement call. The natural rewrite does not compile:

```
error[E0382]: use of moved value: `file`
   --> src/producer.rs:96:46
```

`file` is an `Option<&mut impl Read>` and so not `Copy`, and a value moved in a match guard counts as moved for the whole match, so the three content checks in `handle_file` have to stay in the arm bodies. I put an `#[allow(clippy::collapsible_match)]` on the function with that reason written next to it rather than restructure the match. Happy to do it differently if you would rather.

One thing I deliberately left out: an older clippy (1.95 here) additionally reports `collapsible_match` at `src/parser.rs:742` - the current CI clippy does not. It cannot become a guard either, because the inner condition uses `?`. I left `parser.rs` untouched so this does not conflict with #1515 and #1516, which both change that file. Say the word and I will fold it in.

Checked locally: `cargo clippy --bins --tests --examples --all -- -D rust_2018_idioms -D warnings` is clean apart from that one `parser.rs` line, `cargo fmt -- --check` passes, and `cargo test --lib` is unchanged at 133 passed (the four `llvm_tools` failures here need `llvm-profdata` and fail identically on `master`).