### PR TITLE
Revert "chore: satisfy clippy on the current toolchain"

### DIFF
--- a/src/cobertura.rs
+++ b/src/cobertura.rs
@@ -65,8 +65,8 @@ impl CoverageStats {
         let lines_valid = lines.len() as f64;
 
         let branches: Vec<Vec<Condition>> = lines
-            .into_values()
-            .filter_map(|l| match l {
+            .into_iter()
+            .filter_map(|(_, l)| match l {
                 Line::Branch { conditions, .. } => Some(conditions),
                 Line::Plain { .. } => None,
             })

--- a/src/path_rewriting.rs
+++ b/src/path_rewriting.rs
@@ -417,10 +417,18 @@ pub fn rewrite_paths(
             }
 
             match filter_option {
-                Some(true) if !is_covered(&result) => return None,
-                Some(false) if is_covered(&result) => return None,
-                _ => (),
-            }
+                Some(true) => {
+                    if !is_covered(&result) {
+                        return None;
+                    }
+                }
+                Some(false) => {
+                    if is_covered(&result) {
+                        return None;
+                    }
+                }
+                None => (),
+            };
 
             Some((abs_path, rel_path, result))
         });

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -50,11 +50,6 @@ impl Archive {
             .push(self);
     }
 
-    // The three content checks below read from `file`, which is an
-    // `Option<&mut impl Read>` and so not `Copy`. Moving it in a match guard
-    // makes it moved for the whole match, and the arms stop compiling with
-    // E0382, so the checks have to stay inside the arm bodies.
-    #[allow(clippy::collapsible_match)]
     fn handle_file<'a>(
         &'a self,
         file: Option<&mut impl Read>,
@@ -149,7 +144,8 @@ impl Archive {
 
     fn is_info(reader: &mut dyn Read) -> bool {
         let mut bytes: [u8; 3] = [0; 3];
-        reader.read_exact(&mut bytes).is_ok() && (bytes == *b"TN:" || bytes == *b"SF:")
+        reader.read_exact(&mut bytes).is_ok()
+            && (bytes == [b'T', b'N', b':'] || bytes == [b'S', b'F', b':'])
     }
 
     fn check_file(file: Option<&mut impl Read>, checker: &dyn Fn(&mut dyn Read) -> bool) -> bool {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -581,7 +581,7 @@ fn test_integration_zip_zip() {
 
         // two gcdas
         std::fs::copy(&gcda_zip_path, &gcda1_zip_path)
-            .unwrap_or_else(|_| panic!("Failed to copy {:?}", gcda_zip_path));
+            .unwrap_or_else(|_| panic!("Failed to copy {:?}", &gcda_zip_path));
 
         println!("Two gcdas");
         check_equal_coveralls(


### PR DESCRIPTION
Reverts mozilla/grcov#1518